### PR TITLE
feat: build circulation and admin dashboards

### DIFF
--- a/frontend-react/src/components/Layout/AppHeader.tsx
+++ b/frontend-react/src/components/Layout/AppHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Layout, Button, Dropdown, Avatar, Space } from 'antd';
 import { UserOutlined, LogoutOutlined, SettingOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { useAuth } from '../../../contexts/AuthContext';
+import { useAuth } from '../../contexts/AuthContext';
 
 const { Header } = Layout;
 

--- a/frontend-react/src/components/Layout/AppSider.tsx
+++ b/frontend-react/src/components/Layout/AppSider.tsx
@@ -1,105 +1,123 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Layout, Menu } from 'antd';
+import type { MenuProps } from 'antd';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   DashboardOutlined,
   BookOutlined,
-  UserOutlined,
   FileTextOutlined,
   CalendarOutlined,
   DollarOutlined,
   TeamOutlined,
   HistoryOutlined,
 } from '@ant-design/icons';
-import { useAuth } from '../../../contexts/AuthContext';
+import { useAuth } from '../../contexts/AuthContext';
 
 const { Sider } = Layout;
 
-const AppSider: React.FC = () => {
+interface AppSiderProps {
+  collapsed: boolean;
+  onCollapse: (collapsed: boolean) => void;
+}
+
+const AppSider: React.FC<AppSiderProps> = ({ collapsed, onCollapse }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useAuth();
 
-  const menuItems = [
-    {
-      key: '/dashboard',
-      icon: <DashboardOutlined />,
-      label: 'Dashboard',
-    },
-    {
-      key: '/books',
-      icon: <BookOutlined />,
-      label: 'Quản lý sách',
-    },
-    {
-      key: '/categories',
-      icon: <FileTextOutlined />,
-      label: 'Thể loại sách',
-      roles: ['admin', 'librarian'],
-    },
-    {
-      key: 'borrows',
-      icon: <CalendarOutlined />,
-      label: 'Mượn sách',
-      children: [
-        {
-          key: '/my-borrows',
-          label: 'Sách đã mượn',
-        },
-        {
-          key: '/borrows',
-          label: 'Quản lý mượn sách',
-          roles: ['admin', 'librarian'],
-        },
-      ],
-    },
-    {
-      key: '/reservations',
-      icon: <CalendarOutlined />,
-      label: 'Đặt trước sách',
-    },
-    {
-      key: '/fines',
-      icon: <DollarOutlined />,
-      label: 'Quản lý phạt',
-    },
-    {
-      key: '/users',
-      icon: <TeamOutlined />,
-      label: 'Quản lý người dùng',
-      roles: ['admin', 'librarian'],
-    },
-    {
-      key: '/activity',
-      icon: <HistoryOutlined />,
-      label: 'Nhật ký hoạt động',
-      roles: ['admin', 'librarian'],
-    },
-  ];
+  type RoleAwareMenuItem = (MenuProps['items'][number] & { roles?: string[]; children?: RoleAwareMenuItem[] });
 
-  // Filter menu items based on user role
-  const filteredMenuItems = menuItems.filter(item => {
-    if (!item.roles) return true;
-    return item.roles.includes(user?.role || '');
-  }).map(item => {
-    if (item.children) {
-      return {
-        ...item,
-        children: item.children.filter(child => {
-          if (!child.roles) return true;
-          return child.roles.includes(user?.role || '');
-        }),
-      };
-    }
-    return item;
-  });
+  const filteredMenuItems = useMemo<MenuProps['items']>(() => {
+    const items: RoleAwareMenuItem[] = [
+      {
+        key: '/dashboard',
+        icon: <DashboardOutlined />,
+        label: 'Dashboard',
+      },
+      {
+        key: '/books',
+        icon: <BookOutlined />,
+        label: 'Quản lý sách',
+      },
+      {
+        key: '/categories',
+        icon: <FileTextOutlined />,
+        label: 'Thể loại sách',
+        roles: ['admin', 'librarian'],
+      },
+      {
+        key: 'borrows',
+        icon: <CalendarOutlined />,
+        label: 'Mượn sách',
+        children: [
+          {
+            key: '/my-borrows',
+            label: 'Sách đã mượn',
+          },
+          {
+            key: '/borrows',
+            label: 'Quản lý mượn sách',
+            roles: ['admin', 'librarian'],
+          },
+        ],
+      },
+      {
+        key: '/reservations',
+        icon: <CalendarOutlined />,
+        label: 'Đặt trước sách',
+      },
+      {
+        key: '/fines',
+        icon: <DollarOutlined />,
+        label: 'Quản lý phạt',
+      },
+      {
+        key: '/users',
+        icon: <TeamOutlined />,
+        label: 'Quản lý người dùng',
+        roles: ['admin', 'librarian'],
+      },
+      {
+        key: '/activity',
+        icon: <HistoryOutlined />,
+        label: 'Nhật ký hoạt động',
+        roles: ['admin', 'librarian'],
+      },
+    ];
+
+    const sanitized = items
+      .filter((item) => {
+        if (!item.roles) return true;
+        return item.roles.includes(user?.role || '');
+      })
+      .map((item) => {
+        if (item.children) {
+          return {
+            ...item,
+            children: item.children.filter((child) => {
+              if (!child.roles) return true;
+              return child.roles.includes(user?.role || '');
+            }),
+          };
+        }
+        return item;
+      });
+
+    return sanitized as MenuProps['items'];
+  }, [user?.role]);
 
   const handleMenuClick = ({ key }: { key: string }) => {
     navigate(key);
   };
 
   return (
-    <Sider width={250} style={{ background: '#fff' }}>
+    <Sider
+      collapsible
+      collapsed={collapsed}
+      onCollapse={onCollapse}
+      width={250}
+      style={{ background: '#fff' }}
+    >
       <Menu
         mode="inline"
         selectedKeys={[location.pathname]}

--- a/frontend-react/src/components/Layout/MainLayout.tsx
+++ b/frontend-react/src/components/Layout/MainLayout.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Layout } from 'antd';
+import { Outlet } from 'react-router-dom';
+import AppHeader from './AppHeader';
+import AppSider from './AppSider';
+
+const { Content } = Layout;
+
+const MainLayout: React.FC = () => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <Layout style={{ minHeight: '100vh' }}>
+      <AppSider collapsed={collapsed} onCollapse={setCollapsed} />
+      <Layout>
+        <AppHeader />
+        <Content style={{ margin: '24px', padding: 24, background: '#fff', borderRadius: 8 }}>
+          <Outlet />
+        </Content>
+      </Layout>
+    </Layout>
+  );
+};
+
+export default MainLayout;

--- a/frontend-react/src/index.tsx
+++ b/frontend-react/src/index.tsx
@@ -5,7 +5,9 @@ import viVN from 'antd/locale/vi_VN';
 import 'antd/dist/reset.css';
 import './index.css';
 
-import App from './App.js';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from './contexts/AuthContext';
+import AppRouter from './router/AppRouter';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -14,7 +16,11 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ConfigProvider locale={viVN}>
-      <App />
+      <BrowserRouter>
+        <AuthProvider>
+          <AppRouter />
+        </AuthProvider>
+      </BrowserRouter>
     </ConfigProvider>
   </React.StrictMode>
 );

--- a/frontend-react/src/pages/Activity/ActivityLogs.tsx
+++ b/frontend-react/src/pages/Activity/ActivityLogs.tsx
@@ -1,15 +1,347 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Table,
+  Tag,
+  Space,
+  Button,
+  Form,
+  Select,
+  DatePicker,
+  Input,
+  message,
+  Typography,
+  Empty,
+  Result,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { TablePaginationConfig } from 'antd/es/table';
+import { DownloadOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import { useAuth } from '../../contexts/AuthContext';
+import { activityService } from '../../services/activityService';
+import { userService } from '../../services/userService';
+import type { ActivityLog, User } from '../../types';
 
-const { Title } = Typography;
+const { RangePicker } = DatePicker;
+const { Title, Text } = Typography;
 
-const ActivityLogs: React.FC = () => {
+const entityLabels: Record<string, string> = {
+  user: 'Người dùng',
+  book: 'Sách',
+  borrow: 'Mượn trả',
+  reservation: 'Đặt trước',
+  category: 'Thể loại',
+  fine: 'Khoản phạt',
+  activity: 'Hoạt động',
+  auth: 'Xác thực',
+  dashboard: 'Dashboard',
+};
+
+const ActivityLogsPage: React.FC = () => {
+  const { user } = useAuth();
+  const canManage = user?.role === 'admin' || user?.role === 'librarian';
+
+  const [activities, setActivities] = useState<ActivityLog[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [pagination, setPagination] = useState<{ current: number; pageSize: number; total: number }>({
+    current: 1,
+    pageSize: 20,
+    total: 0,
+  });
+  const [filters, setFilters] = useState({
+    action: undefined as string | undefined,
+    entity_type: undefined as string | undefined,
+    user_id: undefined as number | undefined,
+    date_from: undefined as string | undefined,
+    date_to: undefined as string | undefined,
+    search: '',
+  });
+
+  const fetchUsers = useCallback(async () => {
+    if (!canManage) return;
+    try {
+      const { users: data } = await userService.getUsers({ limit: 100 });
+      setUsers(data);
+    } catch (error: any) {
+      console.error('Fetch users error:', error);
+    }
+  }, [canManage]);
+
+  const fetchActivities = useCallback(
+    async (page = 1, pageSize = 20) => {
+      try {
+        setLoading(true);
+        const { activities: data, pagination: serverPagination } = await activityService.getActivityLogs({
+          page,
+          limit: pageSize,
+          action: filters.action,
+          entity_type: filters.entity_type,
+          user_id: filters.user_id,
+          date_from: filters.date_from,
+          date_to: filters.date_to,
+        });
+        let results = data;
+        if (filters.search) {
+          const keyword = filters.search.toLowerCase();
+          results = results.filter((item) =>
+            item.action.toLowerCase().includes(keyword) ||
+            item.entity_type.toLowerCase().includes(keyword) ||
+            item.details?.toLowerCase().includes(keyword) ||
+            item.username?.toLowerCase().includes(keyword) ||
+            item.full_name?.toLowerCase().includes(keyword),
+          );
+        }
+        setActivities(results);
+        setPagination({
+          current: serverPagination.currentPage,
+          pageSize: serverPagination.itemsPerPage,
+          total: filters.search ? results.length : serverPagination.totalItems,
+        });
+      } catch (error: any) {
+        console.error('Fetch activities error:', error);
+        message.error(error.response?.data?.message || 'Không thể tải nhật ký hoạt động');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filters],
+  );
+
+  useEffect(() => {
+    if (canManage) {
+      fetchUsers();
+      fetchActivities();
+    }
+  }, [canManage, fetchUsers, fetchActivities]);
+
+  const handleTableChange = (pager: TablePaginationConfig) => {
+    fetchActivities(pager.current, pager.pageSize);
+  };
+
+  const handleExport = async (format: 'json' | 'csv') => {
+    try {
+      const response = await activityService.exportActivityLogs({
+        format,
+        date_from: filters.date_from,
+        date_to: filters.date_to,
+        action: filters.action,
+        entity_type: filters.entity_type,
+        user_id: filters.user_id,
+        limit: 500,
+      });
+      if (format === 'json') {
+        const blob = new Blob([JSON.stringify(response.data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `activity_logs_${Date.now()}.json`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+      } else {
+        const blob = new Blob([response.data], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `activity_logs_${Date.now()}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+      }
+      message.success('Đã xuất nhật ký hoạt động');
+    } catch (error: any) {
+      console.error('Export activity logs error:', error);
+      message.error(error.response?.data?.message || 'Không thể xuất dữ liệu');
+    }
+  };
+
+  const columns: ColumnsType<ActivityLog> = [
+    {
+      title: 'Thời gian',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (value: string) => dayjs(value).format('DD/MM/YYYY HH:mm:ss'),
+    },
+    {
+      title: 'Người thực hiện',
+      dataIndex: 'full_name',
+      key: 'full_name',
+      render: (_: any, record) => (
+        <div>
+          <strong>{record.full_name || 'Hệ thống'}</strong>
+          {record.username && (
+            <>
+              <br />
+              <Text type="secondary">@{record.username}</Text>
+            </>
+          )}
+        </div>
+      ),
+    },
+    {
+      title: 'Hành động',
+      dataIndex: 'action',
+      key: 'action',
+      render: (value: string) => <Tag color="blue">{value}</Tag>,
+    },
+    {
+      title: 'Đối tượng',
+      dataIndex: 'entity_type',
+      key: 'entity_type',
+      render: (value: string) => entityLabels[value] || value,
+    },
+    {
+      title: 'Chi tiết',
+      dataIndex: 'details',
+      key: 'details',
+      render: (value?: string) => value ? <Text code style={{ whiteSpace: 'pre-wrap' }}>{value}</Text> : '—',
+    },
+    {
+      title: 'IP',
+      dataIndex: 'ip_address',
+      key: 'ip_address',
+      render: (value?: string) => value || '—',
+    },
+  ];
+
+  if (!canManage) {
+    return (
+      <Result
+        status="403"
+        title="Không có quyền truy cập"
+        subTitle="Bạn cần quyền thủ thư hoặc quản trị để xem nhật ký hoạt động."
+      />
+    );
+  }
+
   return (
     <div>
       <Title level={2}>Nhật ký hoạt động</Title>
-      <p>Trang nhật ký hoạt động đang được phát triển...</p>
+      <Form
+        layout="inline"
+        style={{ marginBottom: 16 }}
+        onFinish={() => fetchActivities(1, pagination.pageSize)}
+      >
+        <Form.Item label="Hành động">
+          <Select
+            allowClear
+            placeholder="Chọn hành động"
+            style={{ width: 200 }}
+            value={filters.action}
+            onChange={(value) => setFilters((prev) => ({ ...prev, action: value || undefined }))}
+            options={[
+              { value: 'LOGIN', label: 'Đăng nhập' },
+              { value: 'LOGOUT', label: 'Đăng xuất' },
+              { value: 'BORROW_BOOK', label: 'Mượn sách' },
+              { value: 'RETURN_BOOK', label: 'Trả sách' },
+              { value: 'CREATE_RESERVATION', label: 'Tạo đặt trước' },
+              { value: 'CANCEL_RESERVATION', label: 'Hủy đặt trước' },
+              { value: 'PAY_FINE', label: 'Thanh toán phạt' },
+              { value: 'WAIVE_FINE', label: 'Miễn phạt' },
+              { value: 'CREATE_USER', label: 'Tạo người dùng' },
+              { value: 'UPDATE_USER', label: 'Cập nhật người dùng' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item label="Đối tượng">
+          <Select
+            allowClear
+            placeholder="Chọn đối tượng"
+            style={{ width: 160 }}
+            value={filters.entity_type}
+            onChange={(value) => setFilters((prev) => ({ ...prev, entity_type: value || undefined }))}
+            options={Object.entries(entityLabels).map(([value, label]) => ({ value, label }))}
+          />
+        </Form.Item>
+        <Form.Item label="Người dùng">
+          <Select
+            allowClear
+            placeholder="Chọn người dùng"
+            style={{ width: 200 }}
+            showSearch
+            optionFilterProp="label"
+            value={filters.user_id}
+            onChange={(value) => setFilters((prev) => ({ ...prev, user_id: value || undefined }))}
+            options={users.map((item) => ({ label: `${item.full_name} (@${item.username})`, value: item.id }))}
+          />
+        </Form.Item>
+        <Form.Item label="Khoảng thời gian">
+          <RangePicker
+            allowEmpty={[true, true]}
+            value={
+              filters.date_from && filters.date_to
+                ? [dayjs(filters.date_from), dayjs(filters.date_to)]
+                : null
+            }
+            onChange={(dates) => {
+              if (dates && dates[0] && dates[1]) {
+                setFilters((prev) => ({
+                  ...prev,
+                  date_from: dates[0].startOf('day').toISOString(),
+                  date_to: dates[1].endOf('day').toISOString(),
+                }));
+              } else {
+                setFilters((prev) => ({ ...prev, date_from: undefined, date_to: undefined }));
+              }
+            }}
+          />
+        </Form.Item>
+        <Form.Item>
+          <Input
+            allowClear
+            placeholder="Tìm kiếm"
+            prefix={<SearchOutlined />}
+            style={{ width: 220 }}
+            value={filters.search}
+            onChange={(event) => setFilters((prev) => ({ ...prev, search: event.target.value }))}
+          />
+        </Form.Item>
+        <Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit">
+              Lọc
+            </Button>
+            <Button onClick={() => {
+              setFilters({ action: undefined, entity_type: undefined, user_id: undefined, date_from: undefined, date_to: undefined, search: '' });
+              fetchActivities(1, pagination.pageSize);
+            }}>
+              Đặt lại
+            </Button>
+            <Button icon={<ReloadOutlined />} onClick={() => fetchActivities(pagination.current, pagination.pageSize)}>
+              Tải lại
+            </Button>
+          </Space>
+        </Form.Item>
+      </Form>
+
+      <Space style={{ marginBottom: 16 }}>
+        <Button icon={<DownloadOutlined />} onClick={() => handleExport('json')}>
+          Xuất JSON
+        </Button>
+        <Button icon={<DownloadOutlined />} onClick={() => handleExport('csv')}>
+          Xuất CSV
+        </Button>
+      </Space>
+
+      <Table<ActivityLog>
+        rowKey="id"
+        loading={loading}
+        columns={columns}
+        dataSource={activities}
+        pagination={{
+          current: pagination.current,
+          pageSize: pagination.pageSize,
+          total: pagination.total,
+          showSizeChanger: true,
+        }}
+        onChange={handleTableChange}
+        locale={{ emptyText: <Empty description="Không có hoạt động" /> }}
+      />
     </div>
   );
 };
 
-export default ActivityLogs;
+export default ActivityLogsPage;

--- a/frontend-react/src/pages/Auth/Login.tsx
+++ b/frontend-react/src/pages/Auth/Login.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, Input, Button, Card, Typography, message } from 'antd';
+import { Form, Input, Button, Card, Typography } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';

--- a/frontend-react/src/pages/Auth/Register.tsx
+++ b/frontend-react/src/pages/Auth/Register.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import { Form, Input, Button, Card, Typography, Select, message } from 'antd';
+import { Form, Input, Button, Card, Typography } from 'antd';
 import { UserOutlined, LockOutlined, MailOutlined, PhoneOutlined } from '@ant-design/icons';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { RegisterData } from '../../types';
 
 const { Title, Text } = Typography;
-const { Option } = Select;
 const { TextArea } = Input;
+
+type RegisterFormValues = RegisterData & { confirmPassword: string };
 
 const Register: React.FC = () => {
   const { register, isLoading } = useAuth();
   const navigate = useNavigate();
 
-  const onFinish = async (values: any) => {
-    const success = await register(values);
+  const onFinish = async (values: RegisterFormValues) => {
+    const { confirmPassword, ...payload } = values;
+    const success = await register(payload);
     if (success) {
       navigate('/login');
     }

--- a/frontend-react/src/pages/Books/Books.tsx
+++ b/frontend-react/src/pages/Books/Books.tsx
@@ -1,13 +1,353 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Form,
+  Input,
+  Modal,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  Select,
+  message,
+  Empty,
+} from 'antd';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
+import { PlusOutlined } from '@ant-design/icons';
+import { bookService, BookQueryParams } from '../../services/bookService';
+import { categoryService } from '../../services/categoryService';
+import { Book, Category, PaginationResponse } from '../../types';
+import { useAuth } from '../../contexts/AuthContext';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
+
+const DEFAULT_PAGINATION: PaginationResponse = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10,
+};
 
 const Books: React.FC = () => {
+  const { user } = useAuth();
+  const [form] = Form.useForm();
+  const [books, setBooks] = useState<Book[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [query, setQuery] = useState<BookQueryParams>({ page: 1, limit: 10 });
+  const [pagination, setPagination] = useState<PaginationResponse>(DEFAULT_PAGINATION);
+  const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
+
+  const isManager = useMemo(() => ['admin', 'librarian'].includes(user?.role ?? ''), [user?.role]);
+
+  const fetchBooks = async (params: BookQueryParams = query) => {
+    try {
+      setLoading(true);
+      const { books: fetchedBooks, pagination: meta } = await bookService.getBooks(params);
+      setBooks(fetchedBooks);
+      setPagination(meta);
+    } catch (error: any) {
+      console.error('Fetch books error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách sách');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchCategories = async () => {
+    try {
+      const data = await categoryService.getCategories();
+      setCategories(data);
+    } catch (error: any) {
+      console.error('Fetch categories error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách thể loại');
+    }
+  };
+
+  useEffect(() => {
+    fetchBooks(query);
+    fetchCategories();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleTableChange = (paginationConfig: TablePaginationConfig) => {
+    const nextQuery: BookQueryParams = {
+      ...query,
+      page: paginationConfig.current || 1,
+      limit: paginationConfig.pageSize || query.limit,
+    };
+    setQuery(nextQuery);
+    fetchBooks(nextQuery);
+  };
+
+  const handleSearch = (value: string) => {
+    const nextQuery: BookQueryParams = {
+      ...query,
+      page: 1,
+      search: value || undefined,
+    };
+    setQuery(nextQuery);
+    fetchBooks(nextQuery);
+  };
+
+  const openCreateModal = () => {
+    setSelectedBook(null);
+    form.resetFields();
+    setModalVisible(true);
+  };
+
+  const openEditModal = (record: Book) => {
+    setSelectedBook(record);
+    form.setFieldsValue({
+      title: record.title,
+      author: record.author,
+      isbn: record.isbn,
+      category_id: record.category_id,
+      total_copies: record.total_copies,
+      publication_year: record.publication_year,
+      language: record.language,
+    });
+    setModalVisible(true);
+  };
+
+  const handleDelete = async (record: Book) => {
+    Modal.confirm({
+      title: 'Xác nhận xoá sách',
+      content: `Bạn có chắc chắn muốn xoá sách "${record.title}"?`,
+      okText: 'Xoá',
+      okButtonProps: { danger: true },
+      cancelText: 'Huỷ',
+      onOk: async () => {
+        try {
+          const response = await bookService.deleteBook(record.id);
+          if (response.success) {
+            message.success('Đã xoá sách thành công');
+            fetchBooks(query);
+          } else {
+            message.error(response.message || 'Không thể xoá sách');
+          }
+        } catch (error: any) {
+          console.error('Delete book error:', error);
+          message.error(error.response?.data?.message || 'Không thể xoá sách');
+        }
+      },
+    });
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      const payload = {
+        ...values,
+        total_copies: Number(values.total_copies),
+        publication_year: values.publication_year ? Number(values.publication_year) : undefined,
+      };
+
+      if (selectedBook) {
+        const response = await bookService.updateBook(selectedBook.id, payload);
+        if (response.success) {
+          message.success('Cập nhật sách thành công');
+        } else {
+          message.error(response.message || 'Không thể cập nhật sách');
+        }
+      } else {
+        const response = await bookService.createBook(payload);
+        if (response.success) {
+          message.success('Thêm sách mới thành công');
+        } else {
+          message.error(response.message || 'Không thể thêm sách');
+        }
+      }
+
+      setModalVisible(false);
+      fetchBooks(query);
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Save book error:', error);
+        message.error(error.response?.data?.message || 'Không thể lưu thông tin sách');
+      }
+    }
+  };
+
+  const columns: ColumnsType<Book> = [
+    {
+      title: 'ISBN',
+      dataIndex: 'isbn',
+      key: 'isbn',
+      width: 140,
+      ellipsis: true,
+    },
+    {
+      title: 'Tiêu đề',
+      dataIndex: 'title',
+      key: 'title',
+      render: (text: string, record) => (
+        <Space direction="vertical" size={0}>
+          <Text strong>{text}</Text>
+          <Text type="secondary">{record.author}</Text>
+        </Space>
+      ),
+    },
+    {
+      title: 'Thể loại',
+      dataIndex: 'category_name',
+      key: 'category_name',
+      render: (value: string) => <Tag color="blue">{value}</Tag>,
+    },
+    {
+      title: 'Ngôn ngữ',
+      dataIndex: 'language',
+      key: 'language',
+      width: 120,
+    },
+    {
+      title: 'Số lượng',
+      dataIndex: 'total_copies',
+      key: 'total_copies',
+      render: (_, record) => (
+        <Space size="small">
+          <Tag color="green">Có sẵn: {record.available_copies}</Tag>
+          <Tag>Số lượng: {record.total_copies}</Tag>
+        </Space>
+      ),
+    },
+    {
+      title: 'Hành động',
+      key: 'actions',
+      width: 150,
+      render: (_, record) => (
+        <Space>
+          {isManager && (
+            <Button type="link" onClick={() => openEditModal(record)}>
+              Sửa
+            </Button>
+          )}
+          {isManager && (
+            <Button type="link" danger onClick={() => handleDelete(record)}>
+              Xoá
+            </Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
   return (
     <div>
-      <Title level={2}>Quản lý sách</Title>
-      <p>Trang quản lý sách đang được phát triển...</p>
+      <Space align="center" style={{ width: '100%', marginBottom: 16, justifyContent: 'space-between' }}>
+        <div>
+          <Title level={2} style={{ marginBottom: 0 }}>
+            Quản lý sách
+          </Title>
+          <Text type="secondary">Theo dõi, tìm kiếm và cập nhật thông tin sách trong thư viện</Text>
+        </div>
+        {isManager && (
+          <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+            Thêm sách
+          </Button>
+        )}
+      </Space>
+
+      <Input.Search
+        placeholder="Tìm kiếm theo tên, tác giả hoặc ISBN"
+        allowClear
+        enterButton="Tìm kiếm"
+        onSearch={handleSearch}
+        style={{ maxWidth: 360, marginBottom: 16 }}
+      />
+
+      <Table<Book>
+        loading={loading}
+        columns={columns}
+        dataSource={books}
+        rowKey="id"
+        pagination={{
+          current: pagination.currentPage,
+          total: pagination.totalItems,
+          pageSize: pagination.itemsPerPage,
+          showSizeChanger: true,
+        }}
+        onChange={handleTableChange}
+        locale={{
+          emptyText: loading ? <></> : <Empty description="Chưa có sách nào" />,
+        }}
+      />
+
+      <Modal
+        title={selectedBook ? 'Chỉnh sửa sách' : 'Thêm sách mới'}
+        open={modalVisible}
+        onOk={handleSubmit}
+        onCancel={() => setModalVisible(false)}
+        okText="Lưu"
+        cancelText="Huỷ"
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" preserve={false}>
+          <Form.Item
+            name="title"
+            label="Tiêu đề"
+            rules={[{ required: true, message: 'Vui lòng nhập tiêu đề sách' }]}
+          >
+            <Input placeholder="Nhập tiêu đề" />
+          </Form.Item>
+
+          <Form.Item
+            name="author"
+            label="Tác giả"
+            rules={[{ required: true, message: 'Vui lòng nhập tên tác giả' }]}
+          >
+            <Input placeholder="Nhập tên tác giả" />
+          </Form.Item>
+
+          <Form.Item
+            name="isbn"
+            label="ISBN"
+            rules={[{ required: true, message: 'Vui lòng nhập mã ISBN' }]}
+          >
+            <Input placeholder="Nhập ISBN" />
+          </Form.Item>
+
+          <Form.Item
+            name="category_id"
+            label="Thể loại"
+            rules={[{ required: true, message: 'Vui lòng chọn thể loại' }]}
+          >
+            <Select
+              placeholder="Chọn thể loại"
+              options={categories.map((category) => ({
+                label: category.name,
+                value: category.id,
+              }))}
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="language"
+            label="Ngôn ngữ"
+            rules={[{ required: true, message: 'Vui lòng nhập ngôn ngữ' }]}
+            initialValue="Tiếng Việt"
+          >
+            <Input placeholder="VD: Tiếng Việt, English" />
+          </Form.Item>
+
+          <Form.Item
+            name="total_copies"
+            label="Số lượng bản"
+            rules={[{ required: true, message: 'Vui lòng nhập số lượng bản' }]}
+          >
+            <Input type="number" min={1} placeholder="Nhập số lượng" />
+          </Form.Item>
+
+          <Form.Item name="publication_year" label="Năm xuất bản">
+            <Input type="number" min={1900} max={new Date().getFullYear()} placeholder="VD: 2024" />
+          </Form.Item>
+
+          <Form.Item name="description" label="Mô tả">
+            <Input.TextArea rows={3} placeholder="Mô tả ngắn về cuốn sách" />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 };

--- a/frontend-react/src/pages/Borrows/Borrows.tsx
+++ b/frontend-react/src/pages/Borrows/Borrows.tsx
@@ -1,15 +1,489 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Tabs,
+  Table,
+  Tag,
+  Space,
+  Button,
+  Input,
+  Select,
+  Modal,
+  Form,
+  message,
+  Typography,
+  Row,
+  Col,
+  Statistic,
+  Spin,
+  Empty,
+} from 'antd';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
+import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { borrowService } from '../../services/borrowService';
+import { bookService } from '../../services/bookService';
+import { useAuth } from '../../contexts/AuthContext';
+import type { Book, Borrow } from '../../types';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
+const { Search } = Input;
 
-const Borrows: React.FC = () => {
+interface BorrowPageProps {
+  defaultTab?: 'admin' | 'member';
+  hideAdminTab?: boolean;
+}
+
+const formatDate = (value?: string) => {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString('vi-VN');
+};
+
+const statusColorMap: Record<Borrow['status'], string> = {
+  borrowed: 'processing',
+  returned: 'success',
+  overdue: 'error',
+  lost: 'warning',
+};
+
+const BorrowPage: React.FC<BorrowPageProps> = ({ defaultTab, hideAdminTab = false }) => {
+  const { user } = useAuth();
+  const initialTab = defaultTab ?? (user?.role === 'member' ? 'member' : 'admin');
+  const [activeTab, setActiveTab] = useState<'admin' | 'member'>(initialTab);
+
+  const [borrowLoading, setBorrowLoading] = useState(false);
+  const [myBorrowLoading, setMyBorrowLoading] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [borrows, setBorrows] = useState<Borrow[]>([]);
+  const [myBorrows, setMyBorrows] = useState<Borrow[]>([]);
+  const [availableBooks, setAvailableBooks] = useState<Book[]>([]);
+  const [booksLoading, setBooksLoading] = useState(false);
+
+  const [statusFilter, setStatusFilter] = useState<string | undefined>();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [pagination, setPagination] = useState<{ current: number; pageSize: number; total: number }>({
+    current: 1,
+    pageSize: 10,
+    total: 0,
+  });
+
+  const [borrowModalVisible, setBorrowModalVisible] = useState(false);
+  const [borrowForm] = Form.useForm();
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  const canManageBorrows = user?.role === 'admin' || user?.role === 'librarian';
+
+  const fetchAvailableBooks = useCallback(async () => {
+    try {
+      setBooksLoading(true);
+      const books = await bookService.getAvailableBooks();
+      setAvailableBooks(books);
+    } catch (error: any) {
+      console.error('Fetch available books error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách sách có sẵn');
+    } finally {
+      setBooksLoading(false);
+    }
+  }, []);
+
+  const fetchBorrows = useCallback(
+    async (page = 1, pageSize = 10) => {
+      if (!canManageBorrows) return;
+      try {
+        setBorrowLoading(true);
+        const { borrows: borrowList, pagination: serverPagination } = await borrowService.getBorrows({
+          page,
+          limit: pageSize,
+          status: statusFilter as Borrow['status'] | undefined,
+        });
+        setBorrows(borrowList);
+        setPagination({
+          current: serverPagination.currentPage,
+          pageSize: serverPagination.itemsPerPage,
+          total: serverPagination.totalItems,
+        });
+      } catch (error: any) {
+        console.error('Fetch borrows error:', error);
+        message.error(error.response?.data?.message || 'Không thể tải danh sách mượn sách');
+      } finally {
+        setBorrowLoading(false);
+      }
+    },
+    [canManageBorrows, statusFilter],
+  );
+
+  const fetchMyBorrows = useCallback(async () => {
+    try {
+      setMyBorrowLoading(true);
+      const data = await borrowService.getMyBorrows();
+      setMyBorrows(data);
+    } catch (error: any) {
+      console.error('Fetch my borrows error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải sách bạn đã mượn');
+    } finally {
+      setMyBorrowLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (canManageBorrows) {
+      fetchBorrows();
+    }
+  }, [canManageBorrows, fetchBorrows]);
+
+  useEffect(() => {
+    fetchMyBorrows();
+  }, [fetchMyBorrows]);
+
+  const filteredBorrows = useMemo(() => {
+    if (!searchTerm) return borrows;
+    const keyword = searchTerm.toLowerCase();
+    return borrows.filter((borrow) => {
+      return (
+        borrow.title?.toLowerCase().includes(keyword) ||
+        borrow.full_name?.toLowerCase().includes(keyword) ||
+        borrow.email?.toLowerCase().includes(keyword) ||
+        borrow.isbn?.toLowerCase().includes(keyword)
+      );
+    });
+  }, [borrows, searchTerm]);
+
+  const myBorrowStats = useMemo(() => {
+    const borrowed = myBorrows.filter((item) => item.status === 'borrowed');
+    const overdue = myBorrows.filter((item) => item.status === 'overdue');
+    return {
+      total: myBorrows.length,
+      borrowed: borrowed.length,
+      overdue: overdue.length,
+    };
+  }, [myBorrows]);
+
+  const tablePagination: TablePaginationConfig | false = searchTerm
+    ? {
+        current: 1,
+        pageSize: filteredBorrows.length || 10,
+        total: filteredBorrows.length,
+        showSizeChanger: false,
+      }
+    : {
+        current: pagination.current,
+        pageSize: pagination.pageSize,
+        total: pagination.total,
+        showSizeChanger: true,
+      };
+
+  const handleTableChange = (pager: TablePaginationConfig) => {
+    if (!searchTerm) {
+      fetchBorrows(pager.current, pager.pageSize);
+    }
+  };
+
+  const handleReturnBook = (record: Borrow) => {
+    Modal.confirm({
+      title: 'Xác nhận trả sách',
+      content: `Xác nhận đánh dấu sách "${record.title}" đã được trả?`,
+      okText: 'Xác nhận',
+      cancelText: 'Hủy',
+      onOk: async () => {
+        try {
+          setSubmitLoading(true);
+          const response = await borrowService.returnBook(record.id);
+          if (response.success !== false) {
+            message.success(response.message || 'Đã cập nhật trạng thái trả sách');
+            fetchBorrows(pagination.current, pagination.pageSize);
+            fetchMyBorrows();
+          } else {
+            message.error(response.message || 'Không thể trả sách');
+          }
+        } catch (error: any) {
+          console.error('Return book error:', error);
+          message.error(error.response?.data?.message || 'Không thể trả sách');
+        } finally {
+          setSubmitLoading(false);
+        }
+      },
+    });
+  };
+
+  const openBorrowModal = () => {
+    if (!availableBooks.length) {
+      fetchAvailableBooks();
+    }
+    borrowForm.resetFields();
+    setBorrowModalVisible(true);
+  };
+
+  const handleBorrowBook = async () => {
+    try {
+      const values = await borrowForm.validateFields();
+      setSubmitLoading(true);
+      const response = await borrowService.createBorrow({
+        book_id: values.book_id,
+        borrow_days: values.borrow_days,
+      });
+      if (response.success) {
+        message.success(response.message || 'Mượn sách thành công');
+        setBorrowModalVisible(false);
+        fetchMyBorrows();
+        if (canManageBorrows) {
+          fetchBorrows(pagination.current, pagination.pageSize);
+        }
+      } else {
+        message.error(response.message || 'Không thể mượn sách');
+      }
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Borrow book error:', error);
+        message.error(error.response?.data?.message || 'Không thể mượn sách');
+      }
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  const adminColumns: ColumnsType<Borrow> = [
+    {
+      title: 'Thành viên',
+      dataIndex: 'full_name',
+      key: 'full_name',
+      render: (_, record) => (
+        <div>
+          <strong>{record.full_name}</strong>
+          <br />
+          <Text type="secondary">{record.email}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Sách',
+      dataIndex: 'title',
+      key: 'title',
+      render: (_, record) => (
+        <div>
+          <strong>{record.title}</strong>
+          <br />
+          <Text type="secondary">ISBN: {record.isbn}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Ngày mượn',
+      dataIndex: 'borrow_date',
+      key: 'borrow_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Hạn trả',
+      dataIndex: 'due_date',
+      key: 'due_date',
+      render: (value: string, record) => (
+        <Tag color={record.status === 'overdue' ? 'error' : 'blue'}>{formatDate(value)}</Tag>
+      ),
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: Borrow['status']) => <Tag color={statusColorMap[value]}>{value.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Thao tác',
+      key: 'action',
+      render: (_, record) => (
+        <Space>
+          <Button
+            icon={<ReloadOutlined />}
+            type="link"
+            disabled={record.status !== 'borrowed' && record.status !== 'overdue'}
+            onClick={() => handleReturnBook(record)}
+          >
+            Trả sách
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  const memberColumns: ColumnsType<Borrow> = [
+    {
+      title: 'Sách',
+      dataIndex: 'title',
+      key: 'title',
+      render: (_, record) => (
+        <div>
+          <strong>{record.title}</strong>
+          <br />
+          <Text type="secondary">{record.author}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Ngày mượn',
+      dataIndex: 'borrow_date',
+      key: 'borrow_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Hạn trả',
+      dataIndex: 'due_date',
+      key: 'due_date',
+      render: (value: string, record) => (
+        <Tag color={record.status === 'overdue' ? 'error' : 'blue'}>{formatDate(value)}</Tag>
+      ),
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: Borrow['status']) => <Tag color={statusColorMap[value]}>{value.toUpperCase()}</Tag>,
+    },
+  ];
+
+  const tabItems: { key: string; label: React.ReactNode; children: React.ReactNode }[] = [];
+
+  if (canManageBorrows && !hideAdminTab) {
+    tabItems.push({
+      key: 'admin',
+      label: 'Quản trị',
+      children: (
+        <div>
+          <Space style={{ marginBottom: 16 }} wrap>
+            <Select
+              allowClear
+              placeholder="Lọc theo trạng thái"
+              value={statusFilter}
+              style={{ width: 200 }}
+              onChange={(value) => {
+                setStatusFilter(value || undefined);
+                setPagination((prev) => ({ ...prev, current: 1 }));
+                fetchBorrows(1, pagination.pageSize);
+              }}
+              options={[
+                { label: 'Đang mượn', value: 'borrowed' },
+                { label: 'Đã trả', value: 'returned' },
+                { label: 'Quá hạn', value: 'overdue' },
+                { label: 'Mất sách', value: 'lost' },
+              ]}
+            />
+            <Search
+              allowClear
+              placeholder="Tìm theo sách, người mượn, email"
+              onSearch={setSearchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              style={{ width: 280 }}
+            />
+            <Button icon={<ReloadOutlined />} onClick={() => fetchBorrows(pagination.current, pagination.pageSize)}>
+              Tải lại
+            </Button>
+          </Space>
+
+          <Table<Borrow>
+            rowKey="id"
+            loading={borrowLoading}
+            columns={adminColumns}
+            dataSource={filteredBorrows}
+            pagination={tablePagination}
+            onChange={handleTableChange}
+            locale={{ emptyText: <Empty description="Không có dữ liệu mượn sách" /> }}
+          />
+        </div>
+      ),
+    });
+  }
+
+  tabItems.push({
+    key: 'member',
+    label: 'Phiếu mượn của tôi',
+    children: (
+      <div>
+        <Row gutter={16} style={{ marginBottom: 16 }}>
+          <Col xs={24} sm={8}>
+            <Statistic title="Tổng số lần mượn" value={myBorrowStats.total} />
+          </Col>
+          <Col xs={24} sm={8}>
+            <Statistic title="Đang mượn" value={myBorrowStats.borrowed} valueStyle={{ color: '#1890ff' }} />
+          </Col>
+          <Col xs={24} sm={8}>
+            <Statistic title="Quá hạn" value={myBorrowStats.overdue} valueStyle={{ color: '#cf1322' }} />
+          </Col>
+        </Row>
+
+        <Space style={{ marginBottom: 16 }} wrap>
+          <Button type="primary" icon={<PlusOutlined />} onClick={openBorrowModal}>
+            Mượn sách
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={fetchMyBorrows}>
+            Làm mới
+          </Button>
+        </Space>
+
+        <Table<Borrow>
+          rowKey="id"
+          loading={myBorrowLoading}
+          columns={memberColumns}
+          dataSource={myBorrows}
+          pagination={{ pageSize: 10 }}
+          locale={{ emptyText: <Empty description="Bạn chưa có phiếu mượn nào" /> }}
+        />
+      </div>
+    ),
+  });
+
   return (
     <div>
       <Title level={2}>Quản lý mượn sách</Title>
-      <p>Trang quản lý mượn sách đang được phát triển...</p>
+      <Tabs activeKey={activeTab} onChange={(key) => setActiveTab(key as 'admin' | 'member')} items={tabItems} />
+
+      <Modal
+        title="Đăng ký mượn sách"
+        open={borrowModalVisible}
+        onCancel={() => setBorrowModalVisible(false)}
+        onOk={handleBorrowBook}
+        okText="Mượn sách"
+        confirmLoading={submitLoading}
+        destroyOnClose
+      >
+        <Spin spinning={booksLoading}>
+          <Form form={borrowForm} layout="vertical" preserve={false}>
+            <Form.Item
+              name="book_id"
+              label="Chọn sách"
+              rules={[{ required: true, message: 'Vui lòng chọn sách muốn mượn' }]}
+            >
+              <Select
+                showSearch
+                placeholder="Chọn sách muốn mượn"
+                optionFilterProp="label"
+                onFocus={fetchAvailableBooks}
+                options={availableBooks.map((book) => ({
+                  label: `${book.title} (${book.available_copies} bản có sẵn)`,
+                  value: book.id,
+                  disabled: book.available_copies <= 0,
+                }))}
+              />
+            </Form.Item>
+
+            <Form.Item
+              name="borrow_days"
+              label="Số ngày mượn"
+              initialValue={14}
+              rules={[{ required: true, message: 'Vui lòng nhập số ngày mượn' }]}
+            >
+              <Select
+                options={[
+                  { value: 7, label: '7 ngày' },
+                  { value: 14, label: '14 ngày' },
+                  { value: 21, label: '21 ngày' },
+                  { value: 28, label: '28 ngày' },
+                ]}
+              />
+            </Form.Item>
+          </Form>
+        </Spin>
+      </Modal>
     </div>
   );
 };
 
-export default Borrows;
+export default BorrowPage;

--- a/frontend-react/src/pages/Borrows/MyBorrows.tsx
+++ b/frontend-react/src/pages/Borrows/MyBorrows.tsx
@@ -1,15 +1,8 @@
 import React from 'react';
-import { Typography } from 'antd';
-
-const { Title } = Typography;
+import BorrowPage from './Borrows';
 
 const MyBorrows: React.FC = () => {
-  return (
-    <div>
-      <Title level={2}>Sách đã mượn</Title>
-      <p>Trang sách đã mượn đang được phát triển...</p>
-    </div>
-  );
+  return <BorrowPage defaultTab="member" hideAdminTab />;
 };
 
 export default MyBorrows;

--- a/frontend-react/src/pages/Categories/Categories.tsx
+++ b/frontend-react/src/pages/Categories/Categories.tsx
@@ -1,13 +1,190 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Button, Form, Input, Modal, Space, Table, Typography, message, Empty } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined } from '@ant-design/icons';
+import { categoryService } from '../../services/categoryService';
+import { Category } from '../../types';
+import { useAuth } from '../../contexts/AuthContext';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 const Categories: React.FC = () => {
+  const { user } = useAuth();
+  const [form] = Form.useForm();
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+
+  const isManager = useMemo(() => ['admin', 'librarian'].includes(user?.role ?? ''), [user?.role]);
+
+  const fetchCategories = async () => {
+    try {
+      setLoading(true);
+      const data = await categoryService.getCategories();
+      setCategories(data);
+    } catch (error: any) {
+      console.error('Fetch categories error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách thể loại');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCategories();
+  }, []);
+
+  const openCreateModal = () => {
+    setSelectedCategory(null);
+    form.resetFields();
+    setModalVisible(true);
+  };
+
+  const openEditModal = (record: Category) => {
+    setSelectedCategory(record);
+    form.setFieldsValue({ name: record.name, description: record.description });
+    setModalVisible(true);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      if (selectedCategory) {
+        const response = await categoryService.updateCategory(selectedCategory.id, values);
+        if (response.success) {
+          message.success('Cập nhật thể loại thành công');
+        } else {
+          message.error(response.message || 'Không thể cập nhật thể loại');
+        }
+      } else {
+        const response = await categoryService.createCategory(values);
+        if (response.success) {
+          message.success('Thêm thể loại mới thành công');
+        } else {
+          message.error(response.message || 'Không thể thêm thể loại');
+        }
+      }
+
+      setModalVisible(false);
+      fetchCategories();
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Save category error:', error);
+        message.error(error.response?.data?.message || 'Không thể lưu thể loại');
+      }
+    }
+  };
+
+  const handleDelete = async (record: Category) => {
+    Modal.confirm({
+      title: 'Xác nhận xoá thể loại',
+      content: `Bạn có chắc chắn muốn xoá thể loại "${record.name}"?`,
+      okText: 'Xoá',
+      okButtonProps: { danger: true },
+      cancelText: 'Huỷ',
+      onOk: async () => {
+        try {
+          const response = await categoryService.deleteCategory(record.id);
+          if (response.success) {
+            message.success('Đã xoá thể loại thành công');
+            fetchCategories();
+          } else {
+            message.error(response.message || 'Không thể xoá thể loại');
+          }
+        } catch (error: any) {
+          console.error('Delete category error:', error);
+          message.error(error.response?.data?.message || 'Không thể xoá thể loại');
+        }
+      },
+    });
+  };
+
+  const columns: ColumnsType<Category> = [
+    {
+      title: 'Tên thể loại',
+      dataIndex: 'name',
+      key: 'name',
+      render: (text: string) => <Text strong>{text}</Text>,
+    },
+    {
+      title: 'Mô tả',
+      dataIndex: 'description',
+      key: 'description',
+      ellipsis: true,
+      render: (value?: string) => value || '—',
+    },
+    {
+      title: 'Hành động',
+      key: 'actions',
+      width: 160,
+      render: (_, record) => (
+        <Space>
+          {isManager && (
+            <Button type="link" onClick={() => openEditModal(record)}>
+              Sửa
+            </Button>
+          )}
+          {isManager && (
+            <Button type="link" danger onClick={() => handleDelete(record)}>
+              Xoá
+            </Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
   return (
     <div>
-      <Title level={2}>Quản lý thể loại</Title>
-      <p>Trang quản lý thể loại đang được phát triển...</p>
+      <Space align="center" style={{ width: '100%', marginBottom: 16, justifyContent: 'space-between' }}>
+        <div>
+          <Title level={2} style={{ marginBottom: 0 }}>
+            Quản lý thể loại
+          </Title>
+          <Text type="secondary">Tạo mới, chỉnh sửa và quản lý danh sách thể loại sách</Text>
+        </div>
+        {isManager && (
+          <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+            Thêm thể loại
+          </Button>
+        )}
+      </Space>
+
+      <Table<Category>
+        loading={loading}
+        columns={columns}
+        dataSource={categories}
+        rowKey="id"
+        pagination={false}
+        locale={{
+          emptyText: loading ? <></> : <Empty description="Chưa có thể loại" />,
+        }}
+      />
+
+      <Modal
+        title={selectedCategory ? 'Chỉnh sửa thể loại' : 'Thêm thể loại'}
+        open={modalVisible}
+        onOk={handleSubmit}
+        onCancel={() => setModalVisible(false)}
+        okText="Lưu"
+        cancelText="Huỷ"
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" preserve={false}>
+          <Form.Item
+            name="name"
+            label="Tên thể loại"
+            rules={[{ required: true, message: 'Vui lòng nhập tên thể loại' }]}
+          >
+            <Input placeholder="Nhập tên thể loại" />
+          </Form.Item>
+
+          <Form.Item name="description" label="Mô tả">
+            <Input.TextArea rows={3} placeholder="Mô tả ngắn cho thể loại" />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 };

--- a/frontend-react/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend-react/src/pages/Dashboard/Dashboard.tsx
@@ -1,67 +1,292 @@
-import React from 'react';
-import { Card, Row, Col, Statistic, Typography, Spin } from 'antd';
-import { BookOutlined, UserOutlined, CalendarOutlined, DollarOutlined } from '@ant-design/icons';
+import React, { useEffect, useState } from 'react';
+import {
+  Row,
+  Col,
+  Card,
+  Statistic,
+  Typography,
+  List,
+  Progress,
+  Tag,
+  Table,
+  Space,
+  Empty,
+  Spin,
+} from 'antd';
+import {
+  BookOutlined,
+  UserOutlined,
+  CalendarOutlined,
+  DollarOutlined,
+} from '@ant-design/icons';
+import { dashboardService } from '../../services/dashboardService';
+import type {
+  ActivityLog,
+  CategoryStat,
+  DashboardStats,
+  MonthlyBorrow,
+  OverdueReport,
+  RoleStat,
+  TopBook,
+  TopUser,
+} from '../../types';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 const Dashboard: React.FC = () => {
-  // Mock data - trong thực tế sẽ lấy từ API
-  const stats = {
-    totalBooks: 1250,
-    totalMembers: 485,
-    currentBorrows: 89,
-    pendingFines: 12,
+  const [overview, setOverview] = useState<DashboardStats | null>(null);
+  const [monthlyBorrows, setMonthlyBorrows] = useState<MonthlyBorrow[]>([]);
+  const [topBooks, setTopBooks] = useState<TopBook[]>([]);
+  const [categoryStats, setCategoryStats] = useState<CategoryStat[]>([]);
+  const [recentActivity, setRecentActivity] = useState<ActivityLog[]>([]);
+  const [overdueReport, setOverdueReport] = useState<OverdueReport | null>(null);
+  const [roleStats, setRoleStats] = useState<RoleStat[]>([]);
+  const [topUsers, setTopUsers] = useState<TopUser[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchDashboard = async () => {
+      try {
+        setLoading(true);
+        const [{ overview, monthlyBorrows, topBooks, categoryStats }, recentActivityData, overdueData, userStats] = await Promise.all([
+          dashboardService.getOverview(),
+          dashboardService.getRecentActivity(10),
+          dashboardService.getOverdueReport(),
+          dashboardService.getUserStats(),
+        ]);
+
+        setOverview(overview);
+        setMonthlyBorrows(monthlyBorrows);
+        setTopBooks(topBooks);
+        setCategoryStats(categoryStats);
+        setRecentActivity(recentActivityData);
+        setOverdueReport(overdueData);
+        setRoleStats(userStats.roleStats);
+        setTopUsers(userStats.topUsers);
+      } catch (error: any) {
+        console.error('Fetch dashboard error:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDashboard();
+  }, []);
+
+  const renderRoleSummary = () => {
+    if (!roleStats.length) return <Empty description="Không có dữ liệu người dùng" />;
+    const total = roleStats.reduce((sum, stat) => sum + stat.count, 0);
+    return (
+      <List
+        dataSource={roleStats}
+        renderItem={(item) => (
+          <List.Item>
+            <List.Item.Meta
+              title={item.role}
+              description={`${item.count} người dùng`}
+            />
+            <Progress percent={total ? Math.round((item.count / total) * 100) : 0} strokeColor="#1890ff" />
+          </List.Item>
+        )}
+      />
+    );
   };
 
   return (
     <div>
-      <Title level={2}>Dashboard</Title>
-      
-      <Row gutter={[16, 16]}>
-        <Col xs={24} sm={12} lg={6}>
-          <Card>
-            <Statistic
-              title="Tổng số sách"
-              value={stats.totalBooks}
-              prefix={<BookOutlined />}
-              valueStyle={{ color: '#3f8600' }}
-            />
-          </Card>
-        </Col>
-        
-        <Col xs={24} sm={12} lg={6}>
-          <Card>
-            <Statistic
-              title="Thành viên"
-              value={stats.totalMembers}
-              prefix={<UserOutlined />}
-              valueStyle={{ color: '#1890ff' }}
-            />
-          </Card>
-        </Col>
-        
-        <Col xs={24} sm={12} lg={6}>
-          <Card>
-            <Statistic
-              title="Đang mượn"
-              value={stats.currentBorrows}
-              prefix={<CalendarOutlined />}
-              valueStyle={{ color: '#cf1322' }}
-            />
-          </Card>
-        </Col>
-        
-        <Col xs={24} sm={12} lg={6}>
-          <Card>
-            <Statistic
-              title="Phạt chưa thanh toán"
-              value={stats.pendingFines}
-              prefix={<DollarOutlined />}
-              valueStyle={{ color: '#fa8c16' }}
-            />
-          </Card>
-        </Col>
-      </Row>
+      <Title level={2}>Dashboard tổng quan</Title>
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 200 }}>
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          <Row gutter={[16, 16]}>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Tổng số sách"
+                  value={overview?.total_books ?? 0}
+                  prefix={<BookOutlined />}
+                  valueStyle={{ color: '#3f8600' }}
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Thành viên"
+                  value={overview?.total_members ?? 0}
+                  prefix={<UserOutlined />}
+                  valueStyle={{ color: '#1890ff' }}
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Đang mượn"
+                  value={overview?.current_borrows ?? 0}
+                  prefix={<CalendarOutlined />}
+                  valueStyle={{ color: '#fa8c16' }}
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <Card>
+                <Statistic
+                  title="Phạt chờ xử lý"
+                  value={overview?.pending_fines ?? 0}
+                  prefix={<DollarOutlined />}
+                  valueStyle={{ color: '#cf1322' }}
+                />
+              </Card>
+            </Col>
+          </Row>
+
+          <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+            <Col xs={24} lg={12}>
+              <Card title="Xu hướng mượn sách theo tháng">
+                {monthlyBorrows.length ? (
+                  <List
+                    dataSource={monthlyBorrows}
+                    renderItem={(item) => (
+                      <List.Item>
+                        <List.Item.Meta title={item.month} />
+                        <Progress
+                          percent={Math.min(100, Math.round((item.borrow_count / Math.max(...monthlyBorrows.map((m) => m.borrow_count || 1))) * 100))}
+                          format={() => `${item.borrow_count} lượt`}
+                        />
+                      </List.Item>
+                    )}
+                  />
+                ) : (
+                  <Empty description="Chưa có dữ liệu" />
+                )}
+              </Card>
+            </Col>
+            <Col xs={24} lg={12}>
+              <Card title="Top sách được mượn nhiều">
+                {topBooks.length ? (
+                  <List
+                    dataSource={topBooks}
+                    renderItem={(item, index) => (
+                      <List.Item>
+                        <List.Item.Meta
+                          title={
+                            <Space>
+                              <Tag color="blue">#{index + 1}</Tag>
+                              <Text strong>{item.title}</Text>
+                            </Space>
+                          }
+                          description={`Tác giả: ${item.author}`}
+                        />
+                        <Tag color="gold">{item.borrow_count} lượt</Tag>
+                      </List.Item>
+                    )}
+                  />
+                ) : (
+                  <Empty description="Chưa có dữ liệu" />
+                )}
+              </Card>
+            </Col>
+          </Row>
+
+          <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+            <Col xs={24} lg={12}>
+              <Card title="Tình trạng quá hạn" extra={overdueReport ? `Tổng: ${overdueReport.stats.total}` : undefined}>
+                {overdueReport ? (
+                  <List
+                    dataSource={Object.entries(overdueReport.stats.byDays)}
+                    renderItem={([label, value]) => (
+                      <List.Item>
+                        <List.Item.Meta title={`Quá hạn ${label} ngày`} />
+                        <Tag color={value > 0 ? 'red' : 'default'}>{value}</Tag>
+                      </List.Item>
+                    )}
+                  />
+                ) : (
+                  <Empty description="Không có dữ liệu quá hạn" />
+                )}
+              </Card>
+            </Col>
+            <Col xs={24} lg={12}>
+              <Card title="Thống kê người dùng">{renderRoleSummary()}</Card>
+            </Col>
+          </Row>
+
+          <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+            <Col xs={24} lg={12}>
+              <Card title="Top bạn đọc mượn sách">
+                {topUsers.length ? (
+                  <List
+                    dataSource={topUsers}
+                    renderItem={(item, index) => (
+                      <List.Item>
+                        <List.Item.Meta
+                          title={
+                            <Space>
+                              <Tag color="purple">#{index + 1}</Tag>
+                              <Text strong>{item.full_name}</Text>
+                            </Space>
+                          }
+                          description={item.email}
+                        />
+                        <Tag color="green">{item.borrow_count} lượt</Tag>
+                      </List.Item>
+                    )}
+                  />
+                ) : (
+                  <Empty description="Không có dữ liệu" />
+                )}
+              </Card>
+            </Col>
+            <Col xs={24} lg={12}>
+              <Card title="Hoạt động gần đây">
+                {recentActivity.length ? (
+                  <List
+                    dataSource={recentActivity}
+                    renderItem={(item) => (
+                      <List.Item>
+                        <List.Item.Meta
+                          title={
+                            <Space>
+                              <Tag color="blue">{item.action}</Tag>
+                              <Text>{item.entity_type}</Text>
+                            </Space>
+                          }
+                          description={`${item.full_name || 'Hệ thống'} • ${new Date(item.created_at).toLocaleString('vi-VN')}`}
+                        />
+                      </List.Item>
+                    )}
+                  />
+                ) : (
+                  <Empty description="Không có hoạt động" />
+                )}
+              </Card>
+            </Col>
+          </Row>
+
+          <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+            <Col span={24}>
+              <Card title="Tồn kho theo thể loại">
+                <Table<CategoryStat>
+                  rowKey="category_name"
+                  dataSource={categoryStats}
+                  pagination={false}
+                  locale={{ emptyText: <Empty description="Không có dữ liệu" /> }}
+                  columns={[
+                    { title: 'Thể loại', dataIndex: 'category_name', key: 'category_name' },
+                    { title: 'Số sách', dataIndex: 'book_count', key: 'book_count' },
+                    { title: 'Tổng bản sao', dataIndex: 'total_copies', key: 'total_copies' },
+                    { title: 'Có sẵn', dataIndex: 'available_copies', key: 'available_copies' },
+                  ]}
+                />
+              </Card>
+            </Col>
+          </Row>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend-react/src/pages/Fines/Fines.tsx
+++ b/frontend-react/src/pages/Fines/Fines.tsx
@@ -1,15 +1,517 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Tabs,
+  Table,
+  Tag,
+  Space,
+  Button,
+  Modal,
+  Form,
+  Select,
+  InputNumber,
+  Input,
+  message,
+  Typography,
+  Empty,
+  Spin,
+  Row,
+  Col,
+  Statistic,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { TabsProps } from 'antd';
+import { DollarOutlined, ReloadOutlined, CheckCircleOutlined, StopOutlined, PlusOutlined } from '@ant-design/icons';
+import { useAuth } from '../../contexts/AuthContext';
+import { fineService } from '../../services/fineService';
+import { borrowService } from '../../services/borrowService';
+import type { Borrow, Fine } from '../../types';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
-const Fines: React.FC = () => {
+const formatCurrency = (value: number) => new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(value);
+const formatDate = (value?: string) => (value ? new Date(value).toLocaleDateString('vi-VN') : '—');
+
+const statusColors: Record<Fine['status'], string> = {
+  pending: 'warning',
+  paid: 'success',
+  waived: 'default',
+};
+
+const FinesPage: React.FC = () => {
+  const { user } = useAuth();
+  const canManage = user?.role === 'admin' || user?.role === 'librarian';
+
+  const [activeTab, setActiveTab] = useState<'admin' | 'member'>(canManage ? 'admin' : 'member');
+  const [fines, setFines] = useState<Fine[]>([]);
+  const [myFines, setMyFines] = useState<Fine[]>([]);
+  const [borrowOptions, setBorrowOptions] = useState<Borrow[]>([]);
+  const [filteredStatus, setFilteredStatus] = useState<string | undefined>();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [myLoading, setMyLoading] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [borrowLoading, setBorrowLoading] = useState(false);
+  const [createModalVisible, setCreateModalVisible] = useState(false);
+  const [waiveModalVisible, setWaiveModalVisible] = useState(false);
+  const [selectedFine, setSelectedFine] = useState<Fine | null>(null);
+  const [form] = Form.useForm();
+  const [waiveForm] = Form.useForm();
+
+  const fetchFines = useCallback(
+    async (status?: Fine['status']) => {
+      if (!canManage) return;
+      try {
+        setLoading(true);
+        const { fines: data } = await fineService.getFines({ status, limit: 100 });
+        setFines(data);
+      } catch (error: any) {
+        console.error('Fetch fines error:', error);
+        message.error(error.response?.data?.message || 'Không thể tải danh sách phạt');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [canManage],
+  );
+
+  const fetchMyFines = useCallback(async () => {
+    try {
+      setMyLoading(true);
+      const data = await fineService.getMyFines();
+      setMyFines(data);
+    } catch (error: any) {
+      console.error('Fetch my fines error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách phạt của bạn');
+    } finally {
+      setMyLoading(false);
+    }
+  }, []);
+
+  const fetchBorrows = useCallback(async () => {
+    if (!canManage) return;
+    try {
+      setBorrowLoading(true);
+      const { borrows } = await borrowService.getBorrows({ limit: 200, status: 'borrowed' });
+      setBorrowOptions(borrows);
+    } catch (error: any) {
+      console.error('Fetch borrows error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách mượn sách');
+    } finally {
+      setBorrowLoading(false);
+    }
+  }, [canManage]);
+
+  useEffect(() => {
+    if (canManage) {
+      fetchFines();
+      fetchBorrows();
+    }
+  }, [canManage, fetchFines, fetchBorrows]);
+
+  useEffect(() => {
+    fetchMyFines();
+  }, [fetchMyFines]);
+
+  const filteredFines = useMemo(() => {
+    let data = fines;
+    if (filteredStatus) {
+      data = data.filter((fine) => fine.status === filteredStatus);
+    }
+    if (!searchTerm) return data;
+    const keyword = searchTerm.toLowerCase();
+    return data.filter((fine) =>
+      fine.full_name?.toLowerCase().includes(keyword) ||
+      fine.email?.toLowerCase().includes(keyword) ||
+      fine.title?.toLowerCase().includes(keyword),
+    );
+  }, [fines, filteredStatus, searchTerm]);
+
+  const myStats = useMemo(() => {
+    const pending = myFines.filter((fine) => fine.status === 'pending');
+    const paid = myFines.filter((fine) => fine.status === 'paid');
+    return {
+      total: myFines.length,
+      pending: pending.length,
+      paid: paid.length,
+      totalAmount: pending.reduce((sum, fine) => sum + (fine.amount || 0), 0),
+    };
+  }, [myFines]);
+
+  const handlePayFine = async (fine: Fine) => {
+    Modal.confirm({
+      title: 'Thanh toán phạt',
+      content: `Xác nhận đã thanh toán khoản phạt ${formatCurrency(fine.amount)} cho sách "${fine.title}"?`,
+      okText: 'Thanh toán',
+      cancelText: 'Hủy',
+      onOk: async () => {
+        try {
+          setSubmitLoading(true);
+          const response = await fineService.payFine(fine.id);
+          if (response.success) {
+            message.success(response.message || 'Đã thanh toán phạt');
+            fetchMyFines();
+            fetchFines(filteredStatus as Fine['status'] | undefined);
+          } else {
+            message.error(response.message || 'Không thể thanh toán phạt');
+          }
+        } catch (error: any) {
+          console.error('Pay fine error:', error);
+          message.error(error.response?.data?.message || 'Không thể thanh toán phạt');
+        } finally {
+          setSubmitLoading(false);
+        }
+      },
+    });
+  };
+
+  const handleWaiveFine = (fine: Fine) => {
+    setSelectedFine(fine);
+    waiveForm.resetFields();
+    setWaiveModalVisible(true);
+  };
+
+  const submitWaive = async () => {
+    if (!selectedFine) return;
+    try {
+      const values = await waiveForm.validateFields();
+      setSubmitLoading(true);
+      const response = await fineService.waiveFine(selectedFine.id, { reason: values.reason });
+      if (response.success) {
+        message.success(response.message || 'Đã miễn phạt');
+        setWaiveModalVisible(false);
+        fetchFines(filteredStatus as Fine['status'] | undefined);
+      } else {
+        message.error(response.message || 'Không thể miễn phạt');
+      }
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Waive fine error:', error);
+        message.error(error.response?.data?.message || 'Không thể miễn phạt');
+      }
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  const openCreateModal = () => {
+    form.resetFields();
+    setCreateModalVisible(true);
+    if (!borrowOptions.length) {
+      fetchBorrows();
+    }
+  };
+
+  const submitCreate = async () => {
+    try {
+      const values = await form.validateFields();
+      setSubmitLoading(true);
+      const response = await fineService.createFine({
+        borrow_id: values.borrow_id,
+        amount: values.amount,
+        reason: values.reason,
+      });
+      if (response.success) {
+        message.success(response.message || 'Đã tạo khoản phạt');
+        setCreateModalVisible(false);
+        fetchFines(filteredStatus as Fine['status'] | undefined);
+      } else {
+        message.error(response.message || 'Không thể tạo khoản phạt');
+      }
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Create fine error:', error);
+        message.error(error.response?.data?.message || 'Không thể tạo khoản phạt');
+      }
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  const adminColumns: ColumnsType<Fine> = [
+    {
+      title: 'Bạn đọc',
+      dataIndex: 'full_name',
+      key: 'full_name',
+      render: (_, record) => (
+        <div>
+          <strong>{record.full_name}</strong>
+          <br />
+          <Text type="secondary">{record.email}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Sách',
+      dataIndex: 'title',
+      key: 'title',
+      render: (_, record) => (
+        <div>
+          <strong>{record.title}</strong>
+          <br />
+          <Text type="secondary">Ngày mượn: {formatDate(record.borrow_date || record.created_at)}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Số tiền',
+      dataIndex: 'amount',
+      key: 'amount',
+      render: (value: number) => formatCurrency(value),
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: Fine['status']) => <Tag color={statusColors[value]}>{value.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Ngày đến hạn',
+      dataIndex: 'due_date',
+      key: 'due_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Thao tác',
+      key: 'actions',
+      render: (_, record) => (
+        <Space>
+          <Button
+            icon={<CheckCircleOutlined />}
+            type="link"
+            disabled={record.status !== 'pending'}
+            onClick={() => handlePayFine(record)}
+          >
+            Đã thu
+          </Button>
+          <Button
+            icon={<StopOutlined />}
+            type="link"
+            danger
+            disabled={record.status !== 'pending'}
+            onClick={() => handleWaiveFine(record)}
+          >
+            Miễn phạt
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  const memberColumns: ColumnsType<Fine> = [
+    {
+      title: 'Sách',
+      dataIndex: 'title',
+      key: 'title',
+      render: (_, record) => (
+        <div>
+          <strong>{record.title}</strong>
+          <br />
+          <Text type="secondary">Ngày mượn: {formatDate(record.borrow_date || record.created_at)}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Số tiền',
+      dataIndex: 'amount',
+      key: 'amount',
+      render: (value: number) => formatCurrency(value),
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: Fine['status']) => <Tag color={statusColors[value]}>{value.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Ngày đến hạn',
+      dataIndex: 'due_date',
+      key: 'due_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Thao tác',
+      key: 'action',
+      render: (_, record) => (
+        <Button
+          type="link"
+          icon={<DollarOutlined />}
+          disabled={record.status !== 'pending'}
+          onClick={() => handlePayFine(record)}
+        >
+          Thanh toán
+        </Button>
+      ),
+    },
+  ];
+
+  const tabItems: NonNullable<TabsProps['items']> = [];
+
+  if (canManage) {
+    tabItems.push({
+      key: 'admin',
+      label: 'Quản trị',
+      children: (
+        <div>
+          <Space style={{ marginBottom: 16 }} wrap>
+            <Select
+              allowClear
+              placeholder="Trạng thái"
+              value={filteredStatus}
+              style={{ width: 180 }}
+              onChange={(value) => {
+                setFilteredStatus(value || undefined);
+                fetchFines((value || undefined) as Fine['status'] | undefined);
+              }}
+              options={[
+                { label: 'Đang chờ', value: 'pending' },
+                { label: 'Đã thanh toán', value: 'paid' },
+                { label: 'Đã miễn', value: 'waived' },
+              ]}
+            />
+            <Input.Search
+              allowClear
+              placeholder="Tìm theo sách hoặc bạn đọc"
+              onSearch={setSearchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              style={{ width: 260 }}
+            />
+            <Button icon={<ReloadOutlined />} onClick={() => fetchFines(filteredStatus as Fine['status'] | undefined)}>
+              Tải lại
+            </Button>
+            <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+              Thêm khoản phạt
+            </Button>
+          </Space>
+
+          <Table<Fine>
+            rowKey="id"
+            loading={loading}
+            columns={adminColumns}
+            dataSource={filteredFines}
+            pagination={{ pageSize: 10 }}
+            locale={{ emptyText: <Empty description="Không có khoản phạt" /> }}
+          />
+        </div>
+      ),
+    });
+  }
+
+  tabItems.push({
+    key: 'member',
+    label: 'Khoản phạt của tôi',
+    children: (
+      <div>
+        <Row gutter={16} style={{ marginBottom: 16 }}>
+          <Col xs={24} sm={8}>
+            <Statistic title="Tổng khoản phạt" value={myStats.total} />
+          </Col>
+          <Col xs={24} sm={8}>
+            <Statistic title="Chưa thanh toán" value={myStats.pending} valueStyle={{ color: '#fa8c16' }} />
+          </Col>
+          <Col xs={24} sm={8}>
+            <Statistic title="Đã thanh toán" value={myStats.paid} valueStyle={{ color: '#52c41a' }} />
+          </Col>
+        </Row>
+        <Row gutter={16} style={{ marginBottom: 16 }}>
+          <Col xs={24} sm={12}>
+            <Statistic title="Tổng nợ hiện tại" value={formatCurrency(myStats.totalAmount)} />
+          </Col>
+        </Row>
+
+        <Button icon={<ReloadOutlined />} onClick={fetchMyFines} style={{ marginBottom: 16 }}>
+          Làm mới
+        </Button>
+
+        <Table<Fine>
+          rowKey="id"
+          loading={myLoading}
+          columns={memberColumns}
+          dataSource={myFines}
+          pagination={{ pageSize: 10 }}
+          locale={{ emptyText: <Empty description="Bạn không có khoản phạt nào" /> }}
+        />
+      </div>
+    ),
+  });
+
   return (
     <div>
       <Title level={2}>Quản lý phạt</Title>
-      <p>Trang quản lý phạt đang được phát triển...</p>
+      <Tabs activeKey={activeTab} onChange={(key) => setActiveTab(key as 'admin' | 'member')} items={tabItems} />
+
+      <Modal
+        title="Thêm khoản phạt"
+        open={createModalVisible}
+        onCancel={() => setCreateModalVisible(false)}
+        onOk={submitCreate}
+        okText="Tạo phạt"
+        confirmLoading={submitLoading}
+        destroyOnClose
+      >
+        <Spin spinning={borrowLoading}>
+          <Form layout="vertical" form={form} preserve={false}>
+            <Form.Item
+              name="borrow_id"
+              label="Phiếu mượn"
+              rules={[{ required: true, message: 'Vui lòng chọn phiếu mượn' }]}
+            >
+              <Select
+                showSearch
+                placeholder="Chọn phiếu mượn đang còn"
+                optionFilterProp="label"
+                onFocus={fetchBorrows}
+                options={borrowOptions.map((borrow) => ({
+                  value: borrow.id,
+                  label: `${borrow.full_name} - ${borrow.title} (hạn ${formatDate(borrow.due_date)})`,
+                }))}
+                notFoundContent={borrowLoading ? <Spin size="small" /> : 'Không có phiếu mượn phù hợp'}
+              />
+            </Form.Item>
+            <Form.Item
+              name="amount"
+              label="Số tiền phạt"
+              rules={[{ required: true, message: 'Vui lòng nhập số tiền phạt' }]}
+            >
+              <InputNumber
+                min={0}
+                step={1000}
+                style={{ width: '100%' }}
+                formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                parser={(value) => value?.replace(/\s?/g, '').replace(/,/g, '') || ''}
+              />
+            </Form.Item>
+            <Form.Item
+              name="reason"
+              label="Lý do"
+              rules={[{ required: true, message: 'Vui lòng nhập lý do phạt' }]}
+            >
+              <Input.TextArea rows={3} placeholder="Nhập lý do phạt" />
+            </Form.Item>
+          </Form>
+        </Spin>
+      </Modal>
+
+      <Modal
+        title="Miễn khoản phạt"
+        open={waiveModalVisible}
+        onCancel={() => setWaiveModalVisible(false)}
+        onOk={submitWaive}
+        okText="Miễn phạt"
+        confirmLoading={submitLoading}
+        destroyOnClose
+      >
+        <Form layout="vertical" form={waiveForm} preserve={false}>
+          <Form.Item
+            name="reason"
+            label="Ghi chú"
+            rules={[{ required: false }]}
+          >
+            <Input.TextArea rows={3} placeholder="Lý do miễn phạt (tùy chọn)" />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 };
 
-export default Fines;
+export default FinesPage;

--- a/frontend-react/src/pages/Reservations/Reservations.tsx
+++ b/frontend-react/src/pages/Reservations/Reservations.tsx
@@ -1,15 +1,463 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Tabs,
+  Table,
+  Tag,
+  Space,
+  Button,
+  Modal,
+  Form,
+  Select,
+  message,
+  Typography,
+  Input,
+  Row,
+  Col,
+  Statistic,
+  Empty,
+  Spin,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { TabsProps } from 'antd';
+import { PlusOutlined, ReloadOutlined, CheckOutlined, CloseCircleOutlined } from '@ant-design/icons';
+import { useAuth } from '../../contexts/AuthContext';
+import { reservationService } from '../../services/reservationService';
+import { bookService } from '../../services/bookService';
+import type { Book, Reservation } from '../../types';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
+const { Search } = Input;
 
-const Reservations: React.FC = () => {
+const formatDate = (value?: string) => {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString('vi-VN');
+};
+
+const statusColors: Record<Reservation['status'], string> = {
+  active: 'processing',
+  fulfilled: 'success',
+  expired: 'default',
+  cancelled: 'error',
+};
+
+const ReservationsPage: React.FC = () => {
+  const { user } = useAuth();
+  const canManage = user?.role === 'admin' || user?.role === 'librarian';
+
+  const [activeTab, setActiveTab] = useState<'admin' | 'member'>(canManage ? 'admin' : 'member');
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [myReservations, setMyReservations] = useState<Reservation[]>([]);
+  const [filteredStatus, setFilteredStatus] = useState<string | undefined>();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [myLoading, setMyLoading] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [booksLoading, setBooksLoading] = useState(false);
+  const [books, setBooks] = useState<Book[]>([]);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [form] = Form.useForm();
+
+  const fetchReservations = useCallback(async () => {
+    if (!canManage) return;
+    try {
+      setLoading(true);
+      const data = await reservationService.getReservations();
+      setReservations(data);
+    } catch (error: any) {
+      console.error('Fetch reservations error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách đặt trước');
+    } finally {
+      setLoading(false);
+    }
+  }, [canManage]);
+
+  const fetchMyReservations = useCallback(async () => {
+    try {
+      setMyLoading(true);
+      const data = await reservationService.getMyReservations();
+      setMyReservations(data);
+    } catch (error: any) {
+      console.error('Fetch my reservations error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách đặt trước của bạn');
+    } finally {
+      setMyLoading(false);
+    }
+  }, []);
+
+  const fetchBooks = useCallback(async () => {
+    try {
+      setBooksLoading(true);
+      const { books: rawBooks } = await bookService.getBooks({ limit: 200 });
+      const unavailableBooks = rawBooks.filter((book) => book.available_copies <= 0);
+      setBooks(unavailableBooks);
+    } catch (error: any) {
+      console.error('Fetch books error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải danh sách sách');
+    } finally {
+      setBooksLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (canManage) {
+      fetchReservations();
+    }
+  }, [canManage, fetchReservations]);
+
+  useEffect(() => {
+    fetchMyReservations();
+  }, [fetchMyReservations]);
+
+  const filteredReservations = useMemo(() => {
+    let data = reservations;
+    if (filteredStatus) {
+      data = data.filter((item) => item.status === filteredStatus);
+    }
+    if (!searchTerm) return data;
+    const keyword = searchTerm.toLowerCase();
+    return data.filter((item) =>
+      item.title?.toLowerCase().includes(keyword) ||
+      item.full_name?.toLowerCase().includes(keyword) ||
+      item.email?.toLowerCase().includes(keyword),
+    );
+  }, [reservations, filteredStatus, searchTerm]);
+
+  const myStats = useMemo(() => {
+    const active = myReservations.filter((item) => item.status === 'active');
+    const fulfilled = myReservations.filter((item) => item.status === 'fulfilled');
+    return {
+      total: myReservations.length,
+      active: active.length,
+      fulfilled: fulfilled.length,
+    };
+  }, [myReservations]);
+
+  const handleCancel = async (reservation: Reservation) => {
+    Modal.confirm({
+      title: 'Hủy đặt trước',
+      content: `Bạn có chắc chắn muốn hủy đặt trước cho sách "${reservation.title}"?`,
+      okText: 'Hủy đặt trước',
+      okButtonProps: { danger: true },
+      cancelText: 'Đóng',
+      onOk: async () => {
+        try {
+          setSubmitLoading(true);
+          const response = await reservationService.cancelReservation(reservation.id);
+          if (response.success) {
+            message.success(response.message || 'Đã hủy đặt trước');
+            fetchMyReservations();
+            fetchReservations();
+          } else {
+            message.error(response.message || 'Không thể hủy đặt trước');
+          }
+        } catch (error: any) {
+          console.error('Cancel reservation error:', error);
+          message.error(error.response?.data?.message || 'Không thể hủy đặt trước');
+        } finally {
+          setSubmitLoading(false);
+        }
+      },
+    });
+  };
+
+  const handleFulfill = async (reservation: Reservation) => {
+    Modal.confirm({
+      title: 'Thực hiện đặt trước',
+      content: `Xác nhận thông báo sách "${reservation.title}" đã sẵn sàng cho bạn đọc?`,
+      okText: 'Thông báo',
+      cancelText: 'Đóng',
+      onOk: async () => {
+        try {
+          setSubmitLoading(true);
+          const response = await reservationService.fulfillReservation(reservation.id);
+          if (response.success) {
+            message.success(response.message || 'Đã cập nhật đặt trước');
+            fetchReservations();
+            fetchMyReservations();
+          } else {
+            message.error(response.message || 'Không thể cập nhật đặt trước');
+          }
+        } catch (error: any) {
+          console.error('Fulfill reservation error:', error);
+          message.error(error.response?.data?.message || 'Không thể cập nhật đặt trước');
+        } finally {
+          setSubmitLoading(false);
+        }
+      },
+    });
+  };
+
+  const openModal = () => {
+    form.resetFields();
+    if (!books.length) {
+      fetchBooks();
+    }
+    setModalVisible(true);
+  };
+
+  const handleCreate = async () => {
+    try {
+      const values = await form.validateFields();
+      setSubmitLoading(true);
+      const response = await reservationService.createReservation({ book_id: values.book_id });
+      if (response.success) {
+        message.success(response.message || 'Đã tạo đặt trước');
+        setModalVisible(false);
+        fetchMyReservations();
+        fetchReservations();
+      } else {
+        message.error(response.message || 'Không thể tạo đặt trước');
+      }
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Create reservation error:', error);
+        message.error(error.response?.data?.message || 'Không thể tạo đặt trước');
+      }
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  const adminColumns: ColumnsType<Reservation> = [
+    {
+      title: 'Bạn đọc',
+      dataIndex: 'full_name',
+      key: 'full_name',
+      render: (_, record) => (
+        <div>
+          <strong>{record.full_name}</strong>
+          <br />
+          <Text type="secondary">{record.email}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Sách',
+      dataIndex: 'title',
+      key: 'title',
+      render: (_, record) => (
+        <div>
+          <strong>{record.title}</strong>
+          <br />
+          <Text type="secondary">Ưu tiên: #{record.priority}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Ngày đặt',
+      dataIndex: 'reservation_date',
+      key: 'reservation_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Hết hạn',
+      dataIndex: 'expiry_date',
+      key: 'expiry_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: Reservation['status']) => <Tag color={statusColors[value]}>{value.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Thao tác',
+      key: 'actions',
+      render: (_, record) => (
+        <Space>
+          <Button
+            type="link"
+            icon={<CheckOutlined />}
+            disabled={record.status !== 'active'}
+            onClick={() => handleFulfill(record)}
+          >
+            Thực hiện
+          </Button>
+          <Button
+            type="link"
+            danger
+            icon={<CloseCircleOutlined />}
+            disabled={record.status !== 'active'}
+            onClick={() => handleCancel(record)}
+          >
+            Hủy
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  const memberColumns: ColumnsType<Reservation> = [
+    {
+      title: 'Sách',
+      dataIndex: 'title',
+      key: 'title',
+      render: (_, record) => (
+        <div>
+          <strong>{record.title}</strong>
+          <br />
+          <Text type="secondary">Tác giả: {record.author}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Ngày đặt',
+      dataIndex: 'reservation_date',
+      key: 'reservation_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Hết hạn',
+      dataIndex: 'expiry_date',
+      key: 'expiry_date',
+      render: (value: string) => formatDate(value),
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: Reservation['status']) => <Tag color={statusColors[value]}>{value.toUpperCase()}</Tag>,
+    },
+    {
+      title: 'Thao tác',
+      key: 'action',
+      render: (_, record) => (
+        <Button
+          type="link"
+          danger
+          disabled={record.status !== 'active'}
+          onClick={() => handleCancel(record)}
+        >
+          Hủy đặt
+        </Button>
+      ),
+    },
+  ];
+
+  const items: NonNullable<TabsProps['items']> = [];
+
+  if (canManage) {
+    items.push({
+      key: 'admin',
+      label: 'Quản trị',
+      children: (
+        <div>
+          <Space style={{ marginBottom: 16 }} wrap>
+            <Select
+              allowClear
+              placeholder="Trạng thái"
+              value={filteredStatus}
+              style={{ width: 180 }}
+              onChange={(value) => setFilteredStatus(value || undefined)}
+              options={[
+                { label: 'Hoạt động', value: 'active' },
+                { label: 'Đã thông báo', value: 'fulfilled' },
+                { label: 'Đã hết hạn', value: 'expired' },
+                { label: 'Đã hủy', value: 'cancelled' },
+              ]}
+            />
+            <Search
+              allowClear
+              placeholder="Tìm theo sách hoặc người dùng"
+              onSearch={setSearchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              style={{ width: 260 }}
+            />
+            <Button icon={<ReloadOutlined />} onClick={fetchReservations}>
+              Tải lại
+            </Button>
+          </Space>
+
+          <Table<Reservation>
+            rowKey="id"
+            loading={loading}
+            columns={adminColumns}
+            dataSource={filteredReservations}
+            pagination={{ pageSize: 10 }}
+            locale={{ emptyText: <Empty description="Không có đặt trước nào" /> }}
+          />
+        </div>
+      ),
+    });
+  }
+
+  items.push({
+    key: 'member',
+    label: 'Đặt trước của tôi',
+    children: (
+      <div>
+        <Row gutter={16} style={{ marginBottom: 16 }}>
+          <Col xs={24} sm={8}>
+            <Statistic title="Tổng đặt trước" value={myStats.total} />
+          </Col>
+          <Col xs={24} sm={8}>
+            <Statistic title="Đang chờ" value={myStats.active} valueStyle={{ color: '#1890ff' }} />
+          </Col>
+          <Col xs={24} sm={8}>
+            <Statistic title="Đã thông báo" value={myStats.fulfilled} valueStyle={{ color: '#52c41a' }} />
+          </Col>
+        </Row>
+
+        <Space style={{ marginBottom: 16 }} wrap>
+          <Button type="primary" icon={<PlusOutlined />} onClick={openModal}>
+            Đặt trước sách
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={fetchMyReservations}>
+            Làm mới
+          </Button>
+        </Space>
+
+        <Table<Reservation>
+          rowKey="id"
+          loading={myLoading}
+          columns={memberColumns}
+          dataSource={myReservations}
+          pagination={{ pageSize: 10 }}
+          locale={{ emptyText: <Empty description="Bạn chưa có đặt trước nào" /> }}
+        />
+      </div>
+    ),
+  });
+
   return (
     <div>
       <Title level={2}>Đặt trước sách</Title>
-      <p>Trang đặt trước sách đang được phát triển...</p>
+      <Tabs activeKey={activeTab} onChange={(key) => setActiveTab(key as 'admin' | 'member')} items={items} />
+
+      <Modal
+        title="Tạo đặt trước"
+        open={modalVisible}
+        onCancel={() => setModalVisible(false)}
+        onOk={handleCreate}
+        okText="Đặt trước"
+        confirmLoading={submitLoading}
+        destroyOnClose
+      >
+        <Spin spinning={booksLoading}>
+          <Form layout="vertical" form={form} preserve={false}>
+            <Form.Item
+              name="book_id"
+              label="Chọn sách"
+              rules={[{ required: true, message: 'Vui lòng chọn sách muốn đặt trước' }]}
+            >
+              <Select
+                showSearch
+                placeholder="Chọn sách đang hết"
+                optionFilterProp="label"
+                onFocus={fetchBooks}
+                options={books.map((book) => ({
+                  value: book.id,
+                  label: `${book.title} (đang hết sách)`,
+                }))}
+                notFoundContent={booksLoading ? <Spin size="small" /> : 'Không có sách cần đặt trước'}
+              />
+            </Form.Item>
+          </Form>
+        </Spin>
+      </Modal>
     </div>
   );
 };
 
-export default Reservations;
+export default ReservationsPage;

--- a/frontend-react/src/pages/Users/Users.tsx
+++ b/frontend-react/src/pages/Users/Users.tsx
@@ -1,15 +1,469 @@
-import React from 'react';
-import { Typography } from 'antd';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Table,
+  Tag,
+  Space,
+  Button,
+  Select,
+  Input,
+  Drawer,
+  Descriptions,
+  Modal,
+  Form,
+  message,
+  Typography,
+  Result,
+  Empty,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { TablePaginationConfig } from 'antd/es/table';
+import {
+  EditOutlined,
+  EyeOutlined,
+  LockOutlined,
+  CheckCircleOutlined,
+  StopOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
+import { useAuth } from '../../contexts/AuthContext';
+import { userService } from '../../services/userService';
+import type { User } from '../../types';
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
+const roleLabels: Record<User['role'], string> = {
+  admin: 'Quản trị viên',
+  librarian: 'Thủ thư',
+  member: 'Bạn đọc',
+};
 
-const Users: React.FC = () => {
+const statusTag = (isActive: boolean) => (
+  <Tag color={isActive ? 'success' : 'default'}>{isActive ? 'Đang hoạt động' : 'Đã khóa'}</Tag>
+);
+
+const UsersPage: React.FC = () => {
+  const { user } = useAuth();
+  const canManage = user?.role === 'admin' || user?.role === 'librarian';
+
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [pagination, setPagination] = useState<{ current: number; pageSize: number; total: number }>({
+    current: 1,
+    pageSize: 10,
+    total: 0,
+  });
+  const [roleFilter, setRoleFilter] = useState<User['role'] | undefined>();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [detailVisible, setDetailVisible] = useState(false);
+  const [updateModalVisible, setUpdateModalVisible] = useState(false);
+  const [passwordModalVisible, setPasswordModalVisible] = useState(false);
+  const [updateForm] = Form.useForm();
+  const [passwordForm] = Form.useForm();
+
+  const fetchUsers = useCallback(
+    async (page = 1, pageSize = 10, role?: User['role']) => {
+      if (!canManage) return;
+      try {
+        setLoading(true);
+        const { users: data, pagination: serverPagination } = await userService.getUsers({
+          page,
+          limit: pageSize,
+          role,
+        });
+        setUsers(data);
+        setPagination({
+          current: serverPagination.currentPage,
+          pageSize: serverPagination.itemsPerPage,
+          total: serverPagination.totalItems,
+        });
+      } catch (error: any) {
+        console.error('Fetch users error:', error);
+        message.error(error.response?.data?.message || 'Không thể tải danh sách người dùng');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [canManage],
+  );
+
+  useEffect(() => {
+    if (canManage) {
+      fetchUsers();
+    }
+  }, [canManage, fetchUsers]);
+
+  const filteredUsers = useMemo(() => {
+    if (!searchTerm) return users;
+    const keyword = searchTerm.toLowerCase();
+    return users.filter((item) =>
+      item.full_name?.toLowerCase().includes(keyword) ||
+      item.email?.toLowerCase().includes(keyword) ||
+      item.username.toLowerCase().includes(keyword),
+    );
+  }, [users, searchTerm]);
+
+  const handleTableChange = (pager: TablePaginationConfig) => {
+    if (!searchTerm) {
+      fetchUsers(pager.current, pager.pageSize, roleFilter);
+    } else {
+      setPagination((prev) => ({
+        ...prev,
+        current: pager.current || prev.current,
+        pageSize: pager.pageSize || prev.pageSize,
+      }));
+    }
+  };
+
+  const openDetail = async (record: User) => {
+    try {
+      setActionLoading(true);
+      const data = await userService.getUserById(record.id);
+      setSelectedUser(data);
+      setDetailVisible(true);
+    } catch (error: any) {
+      console.error('Get user detail error:', error);
+      message.error(error.response?.data?.message || 'Không thể tải thông tin người dùng');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const openUpdateModal = (record: User) => {
+    setSelectedUser(record);
+    updateForm.setFieldsValue({
+      full_name: record.full_name,
+      phone: record.phone,
+      address: record.address,
+      role: record.role,
+    });
+    setUpdateModalVisible(true);
+  };
+
+  const submitUpdate = async () => {
+    if (!selectedUser) return;
+    try {
+      const values = await updateForm.validateFields();
+      setActionLoading(true);
+      const payload: Partial<User> = {
+        full_name: values.full_name,
+        phone: values.phone,
+        address: values.address,
+      };
+      if (user?.role === 'admin' && values.role) {
+        payload.role = values.role;
+      }
+      const response = await userService.updateUser(selectedUser.id, payload);
+      if (response.success) {
+        message.success(response.message || 'Đã cập nhật thông tin người dùng');
+        setUpdateModalVisible(false);
+        fetchUsers(pagination.current, pagination.pageSize, roleFilter);
+      } else {
+        message.error(response.message || 'Không thể cập nhật thông tin');
+      }
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Update user error:', error);
+        message.error(error.response?.data?.message || 'Không thể cập nhật thông tin');
+      }
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const openPasswordModal = (record: User) => {
+    setSelectedUser(record);
+    passwordForm.setFieldsValue({
+      current_password: record.id === user?.id ? '' : 'AdminOverride',
+      new_password: '',
+      confirm_password: '',
+    });
+    setPasswordModalVisible(true);
+  };
+
+  const submitPasswordChange = async () => {
+    if (!selectedUser) return;
+    try {
+      const values = await passwordForm.validateFields();
+      setActionLoading(true);
+      const response = await userService.changePassword(selectedUser.id, {
+        current_password: values.current_password,
+        new_password: values.new_password,
+      });
+      if (response.success) {
+        message.success(response.message || 'Đã đổi mật khẩu');
+        setPasswordModalVisible(false);
+      } else {
+        message.error(response.message || 'Không thể đổi mật khẩu');
+      }
+    } catch (error: any) {
+      if (!error?.errorFields) {
+        console.error('Change password error:', error);
+        message.error(error.response?.data?.message || 'Không thể đổi mật khẩu');
+      }
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const toggleStatus = async (record: User) => {
+    Modal.confirm({
+      title: record.is_active ? 'Khóa tài khoản' : 'Kích hoạt tài khoản',
+      content: `Bạn có chắc chắn muốn ${record.is_active ? 'khóa' : 'kích hoạt'} tài khoản ${record.username}?`,
+      okText: 'Xác nhận',
+      cancelText: 'Hủy',
+      onOk: async () => {
+        try {
+          setActionLoading(true);
+          const response = await userService.toggleStatus(record.id);
+          if (response.success) {
+            message.success(response.message || 'Đã cập nhật trạng thái tài khoản');
+            fetchUsers(pagination.current, pagination.pageSize, roleFilter);
+          } else {
+            message.error(response.message || 'Không thể cập nhật trạng thái');
+          }
+        } catch (error: any) {
+          console.error('Toggle status error:', error);
+          message.error(error.response?.data?.message || 'Không thể cập nhật trạng thái');
+        } finally {
+          setActionLoading(false);
+        }
+      },
+    });
+  };
+
+  const columns: ColumnsType<User> = [
+    {
+      title: 'Tên đăng nhập',
+      dataIndex: 'username',
+      key: 'username',
+    },
+    {
+      title: 'Họ tên',
+      dataIndex: 'full_name',
+      key: 'full_name',
+      render: (value: string, record) => (
+        <div>
+          <strong>{value}</strong>
+          <br />
+          <Text type="secondary">{record.email}</Text>
+        </div>
+      ),
+    },
+    {
+      title: 'Vai trò',
+      dataIndex: 'role',
+      key: 'role',
+      render: (value: User['role']) => <Tag color={value === 'admin' ? 'magenta' : value === 'librarian' ? 'blue' : 'default'}>{roleLabels[value]}</Tag>,
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'is_active',
+      key: 'is_active',
+      render: (value: boolean) => statusTag(value),
+    },
+    {
+      title: 'Ngày tạo',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (value: string) => new Date(value).toLocaleDateString('vi-VN'),
+    },
+    {
+      title: 'Thao tác',
+      key: 'actions',
+      render: (_, record) => (
+        <Space>
+          <Button icon={<EyeOutlined />} onClick={() => openDetail(record)}>
+            Xem
+          </Button>
+          <Button icon={<EditOutlined />} onClick={() => openUpdateModal(record)}>
+            Sửa
+          </Button>
+          <Button icon={<LockOutlined />} onClick={() => openPasswordModal(record)}>
+            Đổi mật khẩu
+          </Button>
+          {user?.role === 'admin' && (
+            <Button
+              icon={record.is_active ? <StopOutlined /> : <CheckCircleOutlined />}
+              danger={record.is_active}
+              onClick={() => toggleStatus(record)}
+            >
+              {record.is_active ? 'Khóa' : 'Kích hoạt'}
+            </Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  if (!canManage) {
+    return (
+      <Result
+        status="403"
+        title="Không có quyền truy cập"
+        subTitle="Bạn cần quyền thủ thư hoặc quản trị để xem trang này."
+      />
+    );
+  }
+
   return (
     <div>
       <Title level={2}>Quản lý người dùng</Title>
-      <p>Trang quản lý người dùng đang được phát triển...</p>
+      <Space style={{ marginBottom: 16 }} wrap>
+        <Select
+          allowClear
+          placeholder="Lọc theo vai trò"
+          value={roleFilter}
+          style={{ width: 200 }}
+          onChange={(value: User['role'] | undefined) => {
+            setRoleFilter(value || undefined);
+            fetchUsers(1, pagination.pageSize, value || undefined);
+          }}
+          options={[
+            { label: 'Quản trị viên', value: 'admin' },
+            { label: 'Thủ thư', value: 'librarian' },
+            { label: 'Bạn đọc', value: 'member' },
+          ]}
+        />
+        <Input.Search
+          allowClear
+          placeholder="Tìm theo tên, email hoặc username"
+          style={{ width: 280 }}
+          onSearch={setSearchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
+        <Button icon={<ReloadOutlined />} onClick={() => fetchUsers(pagination.current, pagination.pageSize, roleFilter)}>
+          Tải lại
+        </Button>
+      </Space>
+
+      <Table<User>
+        rowKey="id"
+        loading={loading}
+        columns={columns}
+        dataSource={filteredUsers}
+        pagination={{
+          current: pagination.current,
+          pageSize: pagination.pageSize,
+          total: searchTerm ? filteredUsers.length : pagination.total,
+          showSizeChanger: true,
+        }}
+        onChange={handleTableChange}
+        locale={{ emptyText: <Empty description="Không có người dùng" /> }}
+      />
+
+      <Drawer
+        title="Thông tin người dùng"
+        open={detailVisible}
+        onClose={() => setDetailVisible(false)}
+        width={400}
+      >
+        {selectedUser ? (
+          <Descriptions column={1} bordered size="small">
+            <Descriptions.Item label="Họ tên">{selectedUser.full_name}</Descriptions.Item>
+            <Descriptions.Item label="Email">{selectedUser.email}</Descriptions.Item>
+            <Descriptions.Item label="Số điện thoại">{selectedUser.phone || '—'}</Descriptions.Item>
+            <Descriptions.Item label="Địa chỉ">{selectedUser.address || '—'}</Descriptions.Item>
+            <Descriptions.Item label="Vai trò">{roleLabels[selectedUser.role]}</Descriptions.Item>
+            <Descriptions.Item label="Trạng thái">{statusTag(selectedUser.is_active)}</Descriptions.Item>
+            <Descriptions.Item label="Ngày tạo">
+              {new Date(selectedUser.created_at).toLocaleString('vi-VN')}
+            </Descriptions.Item>
+          </Descriptions>
+        ) : (
+          <Result icon={<></>} title="Đang tải thông tin..." />
+        )}
+      </Drawer>
+
+      <Modal
+        title="Cập nhật thông tin người dùng"
+        open={updateModalVisible}
+        onCancel={() => setUpdateModalVisible(false)}
+        onOk={submitUpdate}
+        okText="Cập nhật"
+        confirmLoading={actionLoading}
+        destroyOnClose
+      >
+        <Form layout="vertical" form={updateForm} preserve={false}>
+          <Form.Item name="full_name" label="Họ tên" rules={[{ required: true, message: 'Vui lòng nhập họ tên' }]}
+          >
+            <Input placeholder="Nhập họ tên" />
+          </Form.Item>
+          <Form.Item name="phone" label="Số điện thoại">
+            <Input placeholder="Nhập số điện thoại" />
+          </Form.Item>
+          <Form.Item name="address" label="Địa chỉ">
+            <Input.TextArea rows={3} placeholder="Nhập địa chỉ" />
+          </Form.Item>
+          {user?.role === 'admin' && (
+            <Form.Item name="role" label="Vai trò" rules={[{ required: true, message: 'Vui lòng chọn vai trò' }]}
+            >
+              <Select
+                options={[
+                  { label: 'Quản trị viên', value: 'admin' },
+                  { label: 'Thủ thư', value: 'librarian' },
+                  { label: 'Bạn đọc', value: 'member' },
+                ]}
+              />
+            </Form.Item>
+          )}
+        </Form>
+      </Modal>
+
+      <Modal
+        title="Đổi mật khẩu"
+        open={passwordModalVisible}
+        onCancel={() => setPasswordModalVisible(false)}
+        onOk={submitPasswordChange}
+        okText="Cập nhật"
+        confirmLoading={actionLoading}
+        destroyOnClose
+      >
+        <Form layout="vertical" form={passwordForm} preserve={false}>
+          <Form.Item
+            name="current_password"
+            label="Mật khẩu hiện tại"
+            rules={[{ required: true, message: 'Vui lòng nhập mật khẩu hiện tại' }]}
+            extra={selectedUser && selectedUser.id !== user?.id ? 'Quản trị viên có thể nhập bất kỳ giá trị nào' : ''}
+          >
+            <Input.Password placeholder="Nhập mật khẩu hiện tại" />
+          </Form.Item>
+          <Form.Item
+            name="new_password"
+            label="Mật khẩu mới"
+            rules={[
+              { required: true, message: 'Vui lòng nhập mật khẩu mới' },
+              { min: 6, message: 'Mật khẩu phải ít nhất 6 ký tự' },
+              {
+                pattern: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
+                message: 'Mật khẩu phải chứa chữ hoa, chữ thường và số',
+              },
+            ]}
+          >
+            <Input.Password placeholder="Nhập mật khẩu mới" />
+          </Form.Item>
+          <Form.Item
+            name="confirm_password"
+            label="Xác nhận mật khẩu"
+            dependencies={['new_password']}
+            rules={[
+              { required: true, message: 'Vui lòng xác nhận mật khẩu' },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('new_password') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('Mật khẩu xác nhận không khớp'));
+                },
+              }),
+            ]}
+          >
+            <Input.Password placeholder="Nhập lại mật khẩu mới" />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 };
 
-export default Users;
+export default UsersPage;

--- a/frontend-react/src/router/AppRouter.tsx
+++ b/frontend-react/src/router/AppRouter.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import ProtectedRoute from '../components/Auth/ProtectedRoute';
+import MainLayout from '../components/Layout/MainLayout';
+import Dashboard from '../pages/Dashboard/Dashboard';
+import Books from '../pages/Books/Books';
+import AddBook from '../pages/Books/AddBook';
+import EditBook from '../pages/Books/EditBook';
+import BookDetail from '../pages/Books/BookDetail';
+import Categories from '../pages/Categories/Categories';
+import Borrows from '../pages/Borrows/Borrows';
+import MyBorrows from '../pages/Borrows/MyBorrows';
+import Reservations from '../pages/Reservations/Reservations';
+import Fines from '../pages/Fines/Fines';
+import Users from '../pages/Users/Users';
+import ActivityLogs from '../pages/Activity/ActivityLogs';
+import Profile from '../pages/Profile/Profile';
+import Login from '../pages/Auth/Login';
+import Register from '../pages/Auth/Register';
+
+const AppRouter: React.FC = () => {
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+
+      <Route
+        element={(
+          <ProtectedRoute>
+            <MainLayout />
+          </ProtectedRoute>
+        )}
+      >
+        <Route index element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/books" element={<Books />} />
+        <Route path="/books/new" element={<AddBook />} />
+        <Route path="/books/:id" element={<BookDetail />} />
+        <Route path="/books/:id/edit" element={<EditBook />} />
+        <Route path="/categories" element={<Categories />} />
+        <Route path="/borrows" element={<Borrows />} />
+        <Route path="/my-borrows" element={<MyBorrows />} />
+        <Route path="/reservations" element={<Reservations />} />
+        <Route path="/fines" element={<Fines />} />
+        <Route path="/users" element={<Users />} />
+        <Route path="/activity" element={<ActivityLogs />} />
+        <Route path="/profile" element={<Profile />} />
+      </Route>
+
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
+  );
+};
+
+export default AppRouter;

--- a/frontend-react/src/services/activityService.ts
+++ b/frontend-react/src/services/activityService.ts
@@ -1,0 +1,77 @@
+import apiClient from './apiClient';
+import { ActivityLog, ApiResponse, PaginationParams, PaginationResponse } from '../types';
+
+interface ActivityListResponse {
+  activities: ActivityLog[];
+  pagination: PaginationResponse;
+}
+
+export interface ActivityQueryParams extends PaginationParams {
+  action?: string;
+  entity_type?: string;
+  user_id?: number;
+  date_from?: string;
+  date_to?: string;
+}
+
+export const activityService = {
+  async getActivityLogs(params: ActivityQueryParams = {}): Promise<ActivityListResponse> {
+    const response = await apiClient.get<ApiResponse<{ activities: ActivityLog[]; pagination: PaginationResponse }>>(
+      '/api/activity',
+      { params },
+    );
+    const payload = response.data.data;
+    return {
+      activities: payload?.activities ?? [],
+      pagination:
+        payload?.pagination ?? {
+          currentPage: params.page ?? 1,
+          totalPages: 1,
+          totalItems: payload?.activities?.length ?? 0,
+          itemsPerPage: params.limit ?? 20,
+        },
+    };
+  },
+
+  async getMyActivityLogs(params: PaginationParams = {}): Promise<ActivityListResponse> {
+    const response = await apiClient.get<ApiResponse<{ activities: ActivityLog[]; pagination: PaginationResponse }>>(
+      '/api/activity/my',
+      { params },
+    );
+    const payload = response.data.data;
+    return {
+      activities: payload?.activities ?? [],
+      pagination:
+        payload?.pagination ?? {
+          currentPage: params.page ?? 1,
+          totalPages: 1,
+          totalItems: payload?.activities?.length ?? 0,
+          itemsPerPage: params.limit ?? 20,
+        },
+    };
+  },
+
+  async getActivityStats(days = 30): Promise<ApiResponse> {
+    const response = await apiClient.get<ApiResponse>('/api/activity/stats', { params: { days } });
+    return response.data;
+  },
+
+  async exportActivityLogs(
+    params: {
+      format?: 'json' | 'csv';
+      date_from?: string;
+      date_to?: string;
+      limit?: number;
+      action?: string;
+      entity_type?: string;
+      user_id?: number;
+    },
+  ) {
+    const format = params.format ?? 'json';
+    const response = await apiClient.get(`/api/activity/export`, {
+      params,
+      responseType: format === 'csv' ? 'blob' : 'json',
+    });
+    return response;
+  },
+};

--- a/frontend-react/src/services/apiClient.ts
+++ b/frontend-react/src/services/apiClient.ts
@@ -1,0 +1,67 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import Cookies from 'js-cookie';
+
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+type RetryableRequest = AxiosRequestConfig & { _retry?: boolean };
+
+apiClient.interceptors.request.use(
+  (config) => {
+    const token = Cookies.get('accessToken');
+    if (token) {
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest: RetryableRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = Cookies.get('refreshToken');
+        if (refreshToken) {
+          const response = await axios.post(
+            `${API_BASE_URL}/api/auth/refresh`,
+            { refreshToken },
+            { withCredentials: true },
+          );
+
+          if (response.data.success) {
+            const { accessToken, refreshToken: newRefreshToken } = response.data.data;
+            Cookies.set('accessToken', accessToken, { expires: 1 });
+            Cookies.set('refreshToken', newRefreshToken, { expires: 7 });
+
+            originalRequest.headers = originalRequest.headers ?? {};
+            originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+            return apiClient(originalRequest);
+          }
+        }
+      } catch (refreshError) {
+        Cookies.remove('accessToken');
+        Cookies.remove('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default apiClient;

--- a/frontend-react/src/services/authService.ts
+++ b/frontend-react/src/services/authService.ts
@@ -1,99 +1,34 @@
-import axios from 'axios';
-import Cookies from 'js-cookie';
+import apiClient from './apiClient';
 import { ApiResponse, LoginCredentials, RegisterData, User } from '../types';
-
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
-
-// Tạo axios instance
-const api = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// Request interceptor để thêm token
-api.interceptors.request.use(
-  (config) => {
-    const token = Cookies.get('accessToken');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// Response interceptor để handle token expiration
-api.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-
-      try {
-        const refreshToken = Cookies.get('refreshToken');
-        if (refreshToken) {
-          const response = await axios.post(`${API_BASE_URL}/api/auth/refresh`, {
-            refreshToken,
-          });
-
-          if (response.data.success) {
-            const { accessToken, refreshToken: newRefreshToken } = response.data.data;
-            
-            Cookies.set('accessToken', accessToken, { expires: 1 });
-            Cookies.set('refreshToken', newRefreshToken, { expires: 7 });
-            
-            originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-            return api(originalRequest);
-          }
-        }
-      } catch (refreshError) {
-        // Refresh failed, redirect to login
-        Cookies.remove('accessToken');
-        Cookies.remove('refreshToken');
-        window.location.href = '/login';
-        return Promise.reject(refreshError);
-      }
-    }
-
-    return Promise.reject(error);
-  }
-);
 
 export const authService = {
   // Đăng nhập
   async login(credentials: LoginCredentials): Promise<ApiResponse<{ user: User; accessToken: string; refreshToken: string }>> {
-    const response = await api.post('/api/auth/login', credentials);
+    const response = await apiClient.post('/api/auth/login', credentials);
     return response.data;
   },
 
   // Đăng ký
   async register(data: RegisterData): Promise<ApiResponse<{ user: User; accessToken: string; refreshToken: string }>> {
-    const response = await api.post('/api/auth/register', data);
+    const response = await apiClient.post('/api/auth/register', data);
     return response.data;
   },
 
   // Đăng xuất
   async logout(): Promise<ApiResponse> {
-    const response = await api.post('/api/auth/logout');
+    const response = await apiClient.post('/api/auth/logout');
     return response.data;
   },
 
   // Lấy thông tin profile
   async getProfile(): Promise<User> {
-    const response = await api.get('/api/auth/profile');
+    const response = await apiClient.get('/api/auth/profile');
     return response.data.data.user;
   },
 
   // Làm mới token
   async refreshToken(refreshToken: string): Promise<ApiResponse<{ accessToken: string; refreshToken: string }>> {
-    const response = await api.post('/api/auth/refresh', { refreshToken });
+    const response = await apiClient.post('/api/auth/refresh', { refreshToken });
     return response.data;
   },
 };

--- a/frontend-react/src/services/bookService.ts
+++ b/frontend-react/src/services/bookService.ts
@@ -1,0 +1,59 @@
+import apiClient from './apiClient';
+import { ApiResponse, Book, PaginationParams, PaginationResponse } from '../types';
+
+interface BookListResponse {
+  books: Book[];
+  pagination: PaginationResponse;
+}
+
+export interface BookQueryParams extends PaginationParams {
+  search?: string;
+  category?: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export const bookService = {
+  async getBooks(params: BookQueryParams = {}): Promise<BookListResponse> {
+    const response = await apiClient.get<ApiResponse<{ books: Book[]; pagination: PaginationResponse }>>(
+      '/api/books',
+      { params },
+    );
+    const payload = response.data.data;
+    return {
+      books: payload?.books ?? [],
+      pagination:
+        payload?.pagination ?? {
+          currentPage: params.page ?? 1,
+          totalPages: 1,
+          totalItems: payload?.books?.length ?? 0,
+          itemsPerPage: params.limit ?? 10,
+        },
+    };
+  },
+
+  async getAvailableBooks(): Promise<Book[]> {
+    const response = await apiClient.get<ApiResponse<Book[]>>('/api/books/available');
+    return (response.data.data as Book[]) ?? [];
+  },
+
+  async getBookById(id: number): Promise<Book> {
+    const response = await apiClient.get<ApiResponse<Book>>(`/api/books/${id}`);
+    return (response.data.data as Book) ?? ({} as Book);
+  },
+
+  async createBook(data: Partial<Book>): Promise<ApiResponse<Book>> {
+    const response = await apiClient.post<ApiResponse<Book>>('/api/books', data);
+    return response.data;
+  },
+
+  async updateBook(id: number, data: Partial<Book>): Promise<ApiResponse<Book>> {
+    const response = await apiClient.put<ApiResponse<Book>>(`/api/books/${id}`, data);
+    return response.data;
+  },
+
+  async deleteBook(id: number): Promise<ApiResponse> {
+    const response = await apiClient.delete<ApiResponse>(`/api/books/${id}`);
+    return response.data;
+  },
+};

--- a/frontend-react/src/services/borrowService.ts
+++ b/frontend-react/src/services/borrowService.ts
@@ -1,0 +1,56 @@
+import apiClient from './apiClient';
+import { ApiResponse, Borrow, PaginationParams, PaginationResponse } from '../types';
+
+interface BorrowListResponse {
+  borrows: Borrow[];
+  pagination: PaginationResponse;
+}
+
+export interface BorrowQueryParams extends PaginationParams {
+  status?: 'borrowed' | 'returned' | 'overdue' | 'lost';
+}
+
+export const borrowService = {
+  async getBorrows(params: BorrowQueryParams = {}): Promise<BorrowListResponse> {
+    const response = await apiClient.get<ApiResponse<{ borrows: Borrow[]; pagination: PaginationResponse }>>(
+      '/api/borrows',
+      { params },
+    );
+    const payload = response.data.data;
+    return {
+      borrows: payload?.borrows ?? [],
+      pagination:
+        payload?.pagination ?? {
+          currentPage: params.page ?? 1,
+          totalPages: 1,
+          totalItems: payload?.borrows?.length ?? 0,
+          itemsPerPage: params.limit ?? 10,
+        },
+    };
+  },
+
+  async getMyBorrows(): Promise<Borrow[]> {
+    const response = await apiClient.get<ApiResponse<Borrow[]>>('/api/borrows/my');
+    return (response.data.data as Borrow[]) ?? [];
+  },
+
+  async getOverdueBorrows(): Promise<Borrow[]> {
+    const response = await apiClient.get<ApiResponse<Borrow[]>>('/api/borrows/overdue');
+    return (response.data.data as Borrow[]) ?? [];
+  },
+
+  async getBorrowById(id: number): Promise<Borrow> {
+    const response = await apiClient.get<ApiResponse<Borrow>>(`/api/borrows/${id}`);
+    return (response.data.data as Borrow) ?? ({} as Borrow);
+  },
+
+  async createBorrow(data: { book_id: number; borrow_days?: number }): Promise<ApiResponse> {
+    const response = await apiClient.post<ApiResponse>('/api/borrows', data);
+    return response.data;
+  },
+
+  async returnBook(id: number): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/borrows/${id}/return`);
+    return response.data;
+  },
+};

--- a/frontend-react/src/services/categoryService.ts
+++ b/frontend-react/src/services/categoryService.ts
@@ -1,0 +1,29 @@
+import apiClient from './apiClient';
+import { ApiResponse, Category } from '../types';
+
+export const categoryService = {
+  async getCategories(): Promise<Category[]> {
+    const response = await apiClient.get<ApiResponse<Category[]>>('/api/categories');
+    return (response.data.data as Category[]) ?? [];
+  },
+
+  async getCategoryById(id: number): Promise<Category> {
+    const response = await apiClient.get<ApiResponse<Category>>(`/api/categories/${id}`);
+    return (response.data.data as Category) ?? ({} as Category);
+  },
+
+  async createCategory(data: Partial<Category>): Promise<ApiResponse<Category>> {
+    const response = await apiClient.post<ApiResponse<Category>>('/api/categories', data);
+    return response.data;
+  },
+
+  async updateCategory(id: number, data: Partial<Category>): Promise<ApiResponse<Category>> {
+    const response = await apiClient.put<ApiResponse<Category>>(`/api/categories/${id}`, data);
+    return response.data;
+  },
+
+  async deleteCategory(id: number): Promise<ApiResponse> {
+    const response = await apiClient.delete<ApiResponse>(`/api/categories/${id}`);
+    return response.data;
+  },
+};

--- a/frontend-react/src/services/dashboardService.ts
+++ b/frontend-react/src/services/dashboardService.ts
@@ -1,0 +1,60 @@
+import apiClient from './apiClient';
+import {
+  ActivityLog,
+  ApiResponse,
+  CategoryStat,
+  DashboardStats,
+  MonthlyBorrow,
+  OverdueReport,
+  RoleStat,
+  RegistrationStat,
+  TopBook,
+  TopUser,
+} from '../types';
+
+interface DashboardOverviewResponse {
+  overview: DashboardStats;
+  monthlyBorrows: MonthlyBorrow[];
+  topBooks: TopBook[];
+  categoryStats: CategoryStat[];
+}
+
+export const dashboardService = {
+  async getOverview(): Promise<DashboardOverviewResponse> {
+    const response = await apiClient.get<ApiResponse<DashboardOverviewResponse>>('/api/dashboard/stats');
+    return (response.data.data as DashboardOverviewResponse) ?? {
+      overview: {
+        total_books: 0,
+        total_members: 0,
+        current_borrows: 0,
+        overdue_borrows: 0,
+        pending_fines: 0,
+        total_fine_amount: 0,
+      },
+      monthlyBorrows: [],
+      topBooks: [],
+      categoryStats: [],
+    };
+  },
+
+  async getRecentActivity(limit = 20): Promise<ActivityLog[]> {
+    const response = await apiClient.get<ApiResponse<ActivityLog[]>>('/api/dashboard/recent-activity', { params: { limit } });
+    return (response.data.data as ActivityLog[]) ?? [];
+  },
+
+  async getOverdueReport(): Promise<OverdueReport> {
+    const response = await apiClient.get<ApiResponse<OverdueReport>>('/api/dashboard/overdue-report');
+    return (
+      response.data.data as OverdueReport
+    ) ?? { overdueBooks: [], stats: { total: 0, byDays: { '1-7': 0, '8-14': 0, '15-30': 0, '30+': 0 } } };
+  },
+
+  async getUserStats(): Promise<{ roleStats: RoleStat[]; registrationStats: RegistrationStat[]; topUsers: TopUser[] }> {
+    const response = await apiClient.get<
+      ApiResponse<{ roleStats: RoleStat[]; registrationStats: RegistrationStat[]; topUsers: TopUser[] }>
+    >('/api/dashboard/user-stats');
+    return (
+      response.data.data as { roleStats: RoleStat[]; registrationStats: RegistrationStat[]; topUsers: TopUser[] }
+    ) ?? { roleStats: [], registrationStats: [], topUsers: [] };
+  },
+};

--- a/frontend-react/src/services/fineService.ts
+++ b/frontend-react/src/services/fineService.ts
@@ -1,0 +1,51 @@
+import apiClient from './apiClient';
+import { ApiResponse, Fine, PaginationParams, PaginationResponse } from '../types';
+
+interface FineListResponse {
+  fines: Fine[];
+  pagination: PaginationResponse;
+}
+
+export interface FineQueryParams extends PaginationParams {
+  status?: 'pending' | 'paid' | 'waived';
+}
+
+export const fineService = {
+  async getFines(params: FineQueryParams = {}): Promise<FineListResponse> {
+    const response = await apiClient.get<ApiResponse<{ fines: Fine[]; pagination: PaginationResponse }>>(
+      '/api/fines',
+      { params },
+    );
+    const payload = response.data.data;
+    return {
+      fines: payload?.fines ?? [],
+      pagination:
+        payload?.pagination ?? {
+          currentPage: params.page ?? 1,
+          totalPages: 1,
+          totalItems: payload?.fines?.length ?? 0,
+          itemsPerPage: params.limit ?? 10,
+        },
+    };
+  },
+
+  async getMyFines(): Promise<Fine[]> {
+    const response = await apiClient.get<ApiResponse<Fine[]>>('/api/fines/my');
+    return (response.data.data as Fine[]) ?? [];
+  },
+
+  async createFine(data: { borrow_id: number; amount: number; reason: string }): Promise<ApiResponse> {
+    const response = await apiClient.post<ApiResponse>('/api/fines', data);
+    return response.data;
+  },
+
+  async payFine(id: number): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/fines/${id}/pay`);
+    return response.data;
+  },
+
+  async waiveFine(id: number, payload?: { reason?: string }): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/fines/${id}/waive`, payload);
+    return response.data;
+  },
+};

--- a/frontend-react/src/services/reservationService.ts
+++ b/frontend-react/src/services/reservationService.ts
@@ -1,0 +1,29 @@
+import apiClient from './apiClient';
+import { ApiResponse, Reservation } from '../types';
+
+export const reservationService = {
+  async getReservations(): Promise<Reservation[]> {
+    const response = await apiClient.get<ApiResponse<Reservation[]>>('/api/reservations');
+    return (response.data.data as Reservation[]) ?? [];
+  },
+
+  async getMyReservations(): Promise<Reservation[]> {
+    const response = await apiClient.get<ApiResponse<Reservation[]>>('/api/reservations/my');
+    return (response.data.data as Reservation[]) ?? [];
+  },
+
+  async createReservation(data: { book_id: number }): Promise<ApiResponse> {
+    const response = await apiClient.post<ApiResponse>('/api/reservations', data);
+    return response.data;
+  },
+
+  async cancelReservation(id: number): Promise<ApiResponse> {
+    const response = await apiClient.delete<ApiResponse>(`/api/reservations/${id}`);
+    return response.data;
+  },
+
+  async fulfillReservation(id: number): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/reservations/${id}/fulfill`);
+    return response.data;
+  },
+};

--- a/frontend-react/src/services/userService.ts
+++ b/frontend-react/src/services/userService.ts
@@ -1,0 +1,51 @@
+import apiClient from './apiClient';
+import { ApiResponse, PaginationParams, PaginationResponse, User } from '../types';
+
+interface UserListResponse {
+  users: User[];
+  pagination: PaginationResponse;
+}
+
+export interface UserQueryParams extends PaginationParams {
+  role?: 'admin' | 'librarian' | 'member';
+}
+
+export const userService = {
+  async getUsers(params: UserQueryParams = {}): Promise<UserListResponse> {
+    const response = await apiClient.get<ApiResponse<{ users: User[]; pagination: PaginationResponse }>>(
+      '/api/users',
+      { params },
+    );
+    const payload = response.data.data;
+    return {
+      users: payload?.users ?? [],
+      pagination:
+        payload?.pagination ?? {
+          currentPage: params.page ?? 1,
+          totalPages: 1,
+          totalItems: payload?.users?.length ?? 0,
+          itemsPerPage: params.limit ?? 10,
+        },
+    };
+  },
+
+  async getUserById(id: number): Promise<User> {
+    const response = await apiClient.get<ApiResponse<User>>(`/api/users/${id}`);
+    return (response.data.data as User) ?? ({} as User);
+  },
+
+  async updateUser(id: number, data: Partial<User>): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/users/${id}`, data);
+    return response.data;
+  },
+
+  async changePassword(id: number, data: { current_password: string; new_password: string }): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/users/${id}/change-password`, data);
+    return response.data;
+  },
+
+  async toggleStatus(id: number): Promise<ApiResponse> {
+    const response = await apiClient.put<ApiResponse>(`/api/users/${id}/toggle-status`);
+    return response.data;
+  },
+};

--- a/frontend-react/src/types/index.ts
+++ b/frontend-react/src/types/index.ts
@@ -180,6 +180,21 @@ export interface TopUser {
   borrow_count: number;
 }
 
+export interface OverdueReportStats {
+  total: number;
+  byDays: {
+    '1-7': number;
+    '8-14': number;
+    '15-30': number;
+    '30+': number;
+  };
+}
+
+export interface OverdueReport {
+  overdueBooks: Borrow[];
+  stats: OverdueReportStats;
+}
+
 export interface ApiResponse<T = any> {
   success: boolean;
   message?: string;


### PR DESCRIPTION
## Summary
- replace circulation placeholders with tabbed experiences for librarians and members, including borrow creation, reservation fulfilment, and fine settlement flows
- build richer administration screens for users, activity logs, and dashboard analytics using the new service layer
- fix registration payload handling so confirmation passwords are not sent to the backend

## Testing
- npm run lint *(fails: ESLint 9 requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d95d632db08327968e40197144a31f